### PR TITLE
fix: reduce transport memory overhead

### DIFF
--- a/internal/client/transport/kcp.go
+++ b/internal/client/transport/kcp.go
@@ -34,6 +34,7 @@ type KcpTransport struct {
 	poolConnections int32
 	loadConnections int32
 	controlFlow     chan struct{}
+	sessionSlots    *sessionSlots
 }
 
 type KcpConfig struct {
@@ -147,6 +148,7 @@ func NewKcpClient(parentCtx context.Context, config *KcpConfig, logger *logrus.L
 		poolConnections: 0,
 		loadConnections: 0,
 		controlFlow:     make(chan struct{}, 100),
+		sessionSlots:    newSessionSlots(muxPoolLimit(config.ConnPoolSize, config.MaxReceiveBuffer)),
 	}
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
@@ -316,6 +318,10 @@ func (c *KcpTransport) channelDialer() {
 }
 
 func (c *KcpTransport) poolMaintainer() {
+	maxPoolSize := c.sessionSlots.max()
+	if maxPoolSize < c.config.ConnPoolSize*poolGrowthLimit {
+		c.logger.Infof("automatic SMUX pool growth capped at %d sessions (receive buffer: %d bytes)", maxPoolSize, c.config.MaxReceiveBuffer)
+	}
 	for i := 0; i < c.config.ConnPoolSize; i++ { // initial pool filling
 		go c.tunnelDialer()
 	}
@@ -374,8 +380,8 @@ func (c *KcpTransport) poolMaintainer() {
 			metrics.ReportPool(poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, mbps)
 
 			// Dynamically adjust the pool size based on current connections
-			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrow(newPoolSize, c.config.ConnPoolSize)) ||
-				load.wantsMore(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize) {
+			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrowWithin(newPoolSize, c.config.ConnPoolSize, maxPoolSize)) ||
+				load.wantsMoreWithin(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, maxPoolSize) {
 				c.logger.Debugf("increasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d, throughput: %d Mbit/s", newPoolSize, newPoolSize+1, poolConnectionsAvg, loadConnections, mbps)
 				newPoolSize++
 
@@ -474,6 +480,12 @@ func (c *KcpTransport) channelHandler() {
 }
 
 func (c *KcpTransport) tunnelDialer() {
+	if !c.sessionSlots.tryAcquire() {
+		c.logger.Debugf("SMUX session limit reached (%d); skipping tunnel dial", c.sessionSlots.max())
+		return
+	}
+	defer c.sessionSlots.release()
+
 	addr := c.config.Endpoints.Next()
 	c.logger.Debugf("initiating new tunnel connection to address %s", addr)
 

--- a/internal/client/transport/poolload.go
+++ b/internal/client/transport/poolload.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/backpack/backpack/internal/metrics"
@@ -40,7 +41,44 @@ const (
 	// Both triggers respect it: growth was previously unbounded, so a burst of
 	// requests could keep adding connections with nothing to stop it.
 	poolGrowthLimit = 4
+
+	// smuxPoolMemoryBudget preserves the maximum receive-window footprint of
+	// the historical default (8 sessions * 4 growth * 4 MiB). Larger receive
+	// windows therefore trade automatic pool growth for a predictable ceiling
+	// instead of silently multiplying the process's memory exposure.
+	smuxPoolMemoryBudget = 128 * 1024 * 1024
 )
+
+// sessionSlots prevents concurrent pool and control-channel requests from
+// racing past a transport's calculated session limit.
+type sessionSlots struct {
+	limit int32
+	used  atomic.Int32
+}
+
+func newSessionSlots(limit int) *sessionSlots {
+	return &sessionSlots{limit: int32(limit)}
+}
+
+func (s *sessionSlots) tryAcquire() bool {
+	for {
+		used := s.used.Load()
+		if used >= s.limit {
+			return false
+		}
+		if s.used.CompareAndSwap(used, used+1) {
+			return true
+		}
+	}
+}
+
+func (s *sessionSlots) release() {
+	s.used.Add(-1)
+}
+
+func (s *sessionSlots) max() int {
+	return int(s.limit)
+}
 
 // poolLoad turns the tunnel's cumulative byte counters into a per-interval
 // throughput reading.
@@ -78,10 +116,14 @@ func (p *poolLoad) mbps() int {
 // dividing by it is what makes this a statement about how hard each connection
 // is working rather than about the tunnel's total speed.
 func (p *poolLoad) wantsMore(mbps, liveConns, poolSize, configuredSize int) bool {
+	return p.wantsMoreWithin(mbps, liveConns, poolSize, configuredSize, configuredSize*poolGrowthLimit)
+}
+
+func (p *poolLoad) wantsMoreWithin(mbps, liveConns, poolSize, configuredSize, maxSize int) bool {
 	if mbps <= 0 || liveConns <= 0 {
 		return false
 	}
-	if !poolCanGrow(poolSize, configuredSize) {
+	if !poolCanGrowWithin(poolSize, configuredSize, maxSize) {
 		return false
 	}
 	return mbps/liveConns >= poolScaleMbpsPerConn
@@ -89,8 +131,35 @@ func (p *poolLoad) wantsMore(mbps, liveConns, poolSize, configuredSize int) bool
 
 // poolCanGrow bounds the pool so neither trigger can grow it without limit.
 func poolCanGrow(poolSize, configuredSize int) bool {
-	if configuredSize <= 0 {
+	return poolCanGrowWithin(poolSize, configuredSize, configuredSize*poolGrowthLimit)
+}
+
+func poolCanGrowWithin(poolSize, configuredSize, maxSize int) bool {
+	if configuredSize <= 0 || maxSize < configuredSize {
 		return false
 	}
-	return poolSize < configuredSize*poolGrowthLimit
+	return poolSize < maxSize
+}
+
+// muxPoolLimit applies the normal 4x growth cap while also bounding the
+// aggregate SMUX receive windows. An explicitly configured initial pool is
+// always honoured, even when it exceeds the automatic-growth budget.
+func muxPoolLimit(configuredSize, maxReceiveBuffer int) int {
+	if configuredSize <= 0 {
+		return 0
+	}
+
+	growthLimit := configuredSize * poolGrowthLimit
+	if maxReceiveBuffer <= 0 {
+		return growthLimit
+	}
+
+	memoryLimit := smuxPoolMemoryBudget / maxReceiveBuffer
+	if memoryLimit < configuredSize {
+		return configuredSize
+	}
+	if memoryLimit < growthLimit {
+		return memoryLimit
+	}
+	return growthLimit
 }

--- a/internal/client/transport/poolload_test.go
+++ b/internal/client/transport/poolload_test.go
@@ -1,6 +1,10 @@
 package transport
 
-import "testing"
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
 
 // The blind spot this exists to close: a few long-lived streams saturate the
 // connections they already have without ever asking for a new one, so the
@@ -65,5 +69,63 @@ func TestFirstReadingAndCounterResetAreNotMeasurements(t *testing.T) {
 func TestUnconfiguredPoolDoesNotGrow(t *testing.T) {
 	if poolCanGrow(1, 0) {
 		t.Fatal("an unconfigured pool size must not grow")
+	}
+}
+
+func TestMuxPoolLimitBoundsReceiveWindows(t *testing.T) {
+	tests := []struct {
+		name          string
+		configured    int
+		receiveBuffer int
+		want          int
+	}{
+		{name: "default keeps fourfold growth", configured: 8, receiveBuffer: 4 * 1024 * 1024, want: 32},
+		{name: "turbo stops at configured pool", configured: 8, receiveBuffer: 16 * 1024 * 1024, want: 8},
+		{name: "aggressive stops at configured pool", configured: 16, receiveBuffer: 32 * 1024 * 1024, want: 16},
+		{name: "explicit pool is always honoured", configured: 64, receiveBuffer: 4 * 1024 * 1024, want: 64},
+		{name: "invalid receive buffer uses normal cap", configured: 8, receiveBuffer: 0, want: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := muxPoolLimit(tt.configured, tt.receiveBuffer); got != tt.want {
+				t.Fatalf("muxPoolLimit(%d, %d) = %d, want %d", tt.configured, tt.receiveBuffer, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionSlotsCannotRacePastLimit(t *testing.T) {
+	const limit = 8
+	slots := newSessionSlots(limit)
+	start := make(chan struct{})
+	var acquired atomic.Int32
+	var wg sync.WaitGroup
+
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if slots.tryAcquire() {
+				acquired.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := acquired.Load(); got != limit {
+		t.Fatalf("acquired %d session slots, want %d", got, limit)
+	}
+	if slots.tryAcquire() {
+		t.Fatal("slot guard allowed a session past its limit")
+	}
+
+	for range limit {
+		slots.release()
+	}
+	if !slots.tryAcquire() {
+		t.Fatal("released slots should be reusable")
 	}
 }

--- a/internal/client/transport/tcpmux.go
+++ b/internal/client/transport/tcpmux.go
@@ -33,6 +33,7 @@ type TcpMuxTransport struct {
 	poolConnections int32
 	loadConnections int32
 	controlFlow     chan struct{}
+	sessionSlots    *sessionSlots
 	// poolNonce is what the server issued for this run; every pool connection
 	// presents it so the server need not judge them by source address. Empty
 	// against a server too old to issue one.
@@ -93,6 +94,7 @@ func NewMuxClient(parentCtx context.Context, config *TcpMuxConfig, logger *logru
 		poolConnections: 0,
 		loadConnections: 0,
 		controlFlow:     make(chan struct{}, 100),
+		sessionSlots:    newSessionSlots(muxPoolLimit(config.ConnPoolSize, config.MaxReceiveBuffer)),
 	}
 
 	// Seed the first generation through the same path a restart uses, so
@@ -261,6 +263,10 @@ func (c *TcpMuxTransport) channelDialer() {
 }
 
 func (c *TcpMuxTransport) poolMaintainer() {
+	maxPoolSize := c.sessionSlots.max()
+	if maxPoolSize < c.config.ConnPoolSize*poolGrowthLimit {
+		c.logger.Infof("automatic SMUX pool growth capped at %d sessions (receive buffer: %d bytes)", maxPoolSize, c.config.MaxReceiveBuffer)
+	}
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
 		go c.tunnelDialer()
 	}
@@ -319,8 +325,8 @@ func (c *TcpMuxTransport) poolMaintainer() {
 			metrics.ReportPool(poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, mbps)
 
 			// Dynamically adjust the pool size based on current connections
-			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrow(newPoolSize, c.config.ConnPoolSize)) ||
-				load.wantsMore(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize) {
+			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrowWithin(newPoolSize, c.config.ConnPoolSize, maxPoolSize)) ||
+				load.wantsMoreWithin(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, maxPoolSize) {
 				c.logger.Debugf("increasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d, throughput: %d Mbit/s", newPoolSize, newPoolSize+1, poolConnectionsAvg, loadConnections, mbps)
 				newPoolSize++
 
@@ -400,6 +406,12 @@ func (c *TcpMuxTransport) channelHandler() {
 }
 
 func (c *TcpMuxTransport) tunnelDialer() {
+	if !c.sessionSlots.tryAcquire() {
+		c.logger.Debugf("SMUX session limit reached (%d); skipping tunnel dial", c.sessionSlots.max())
+		return
+	}
+	defer c.sessionSlots.release()
+
 	c.logger.Debugf("initiating new tunnel connection to address %s", c.config.RemoteAddr)
 
 	// Dial to the tunnel server

--- a/internal/client/transport/wsmux.go
+++ b/internal/client/transport/wsmux.go
@@ -30,6 +30,7 @@ type WsMuxTransport struct {
 	poolConnections int32
 	loadConnections int32
 	controlFlow     chan struct{}
+	sessionSlots    *sessionSlots
 }
 type WsMuxConfig struct {
 	RemoteAddr string
@@ -81,6 +82,7 @@ func NewWSMuxClient(parentCtx context.Context, config *WsMuxConfig, logger *logr
 		poolConnections: 0,
 		loadConnections: 0,
 		controlFlow:     make(chan struct{}, 100),
+		sessionSlots:    newSessionSlots(muxPoolLimit(config.ConnPoolSize, config.MaxReceiveBuffer)),
 	}
 
 	// Seed the first generation through the same path a restart uses, so
@@ -193,6 +195,10 @@ func (c *WsMuxTransport) channelDialer() {
 }
 
 func (c *WsMuxTransport) poolMaintainer() {
+	maxPoolSize := c.sessionSlots.max()
+	if maxPoolSize < c.config.ConnPoolSize*poolGrowthLimit {
+		c.logger.Infof("automatic SMUX pool growth capped at %d sessions (receive buffer: %d bytes)", maxPoolSize, c.config.MaxReceiveBuffer)
+	}
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
 		go c.tunnelDialer()
 	}
@@ -251,8 +257,8 @@ func (c *WsMuxTransport) poolMaintainer() {
 			metrics.ReportPool(poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, mbps)
 
 			// Dynamically adjust the pool size based on current connections
-			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrow(newPoolSize, c.config.ConnPoolSize)) ||
-				load.wantsMore(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize) {
+			if ((loadConnections+a) > poolConnectionsAvg*b && poolCanGrowWithin(newPoolSize, c.config.ConnPoolSize, maxPoolSize)) ||
+				load.wantsMoreWithin(mbps, poolConnectionsAvg, newPoolSize, c.config.ConnPoolSize, maxPoolSize) {
 				c.logger.Debugf("increasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d, throughput: %d Mbit/s", newPoolSize, newPoolSize+1, poolConnectionsAvg, loadConnections, mbps)
 				newPoolSize++
 
@@ -338,6 +344,12 @@ func (c *WsMuxTransport) channelHandler() {
 }
 
 func (c *WsMuxTransport) tunnelDialer() {
+	if !c.sessionSlots.tryAcquire() {
+		c.logger.Debugf("SMUX session limit reached (%d); skipping tunnel dial", c.sessionSlots.max())
+		return
+	}
+	defer c.sessionSlots.release()
+
 	c.logger.Debugf("initiating new %s tunnel connection to address %s", c.config.Mode, c.config.RemoteAddr)
 
 	// Dial to the tunnel server

--- a/internal/server/transport/ws.go
+++ b/internal/server/transport/ws.go
@@ -250,8 +250,8 @@ func (s *WsTransport) channelHandler(g *wsGen) {
 func (s *WsTransport) tunnelListener(g *wsGen) {
 	addr := s.config.BindAddr
 	upgrader := websocket.Upgrader{
-		ReadBufferSize:   16 * 1024,
-		WriteBufferSize:  16 * 1024,
+		// Zero sizes reuse the HTTP server buffers instead of retaining another
+		// pair of 16 KiB buffers for every upgraded connection.
 		HandshakeTimeout: 45 * time.Second,
 		CheckOrigin: func(r *http.Request) bool {
 			return true

--- a/internal/server/transport/wsmux.go
+++ b/internal/server/transport/wsmux.go
@@ -277,8 +277,8 @@ func (s *WsMuxTransport) channelHandler(g *wsMuxGen) {
 func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 	addr := s.config.BindAddr
 	upgrader := websocket.Upgrader{
-		ReadBufferSize:   16 * 1024,
-		WriteBufferSize:  16 * 1024,
+		// Zero sizes reuse the HTTP server buffers instead of retaining another
+		// pair of 16 KiB buffers for every upgraded connection.
 		HandshakeTimeout: 45 * time.Second,
 		CheckOrigin: func(r *http.Request) bool {
 			return true

--- a/internal/web/sniffer.go
+++ b/internal/web/sniffer.go
@@ -393,8 +393,8 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 		return nil, err
 	}
 
-	// Get all active network connections (TCP, UDP, etc.)
-	connections, err := net.Connections("all")
+	// Count sockets without materialising every connection record on Linux.
+	connectionCount, err := socketCount()
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 		UploadSpeed:    m.formatSpeed(uploadSpeed),
 		TunnelTraffic:  m.convertBytesToReadable(m.totalTraffic),
 		Sniffer:        map[bool]string{true: "Running", false: "Not running"}[m.sniffer],
-		AllConnections: fmt.Sprintf("%d", len(connections)),
+		AllConnections: fmt.Sprintf("%d", connectionCount),
 	}
 
 	return stats, nil

--- a/internal/web/socketcount.go
+++ b/internal/web/socketcount.go
@@ -1,0 +1,33 @@
+package web
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	psnet "github.com/shirou/gopsutil/v4/net"
+)
+
+func portableSocketCount() (int, error) {
+	connections, err := psnet.Connections("all")
+	if err != nil {
+		return 0, err
+	}
+	return len(connections), nil
+}
+
+func parseSocketCount(sockstat []byte) (int, error) {
+	for _, line := range strings.Split(string(sockstat), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 || fields[0] != "sockets:" || fields[1] != "used" {
+			continue
+		}
+
+		count, err := strconv.Atoi(fields[2])
+		if err != nil || count < 0 {
+			return 0, fmt.Errorf("invalid socket count %q", fields[2])
+		}
+		return count, nil
+	}
+	return 0, fmt.Errorf("socket count not found in sockstat")
+}

--- a/internal/web/socketcount_linux.go
+++ b/internal/web/socketcount_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package web
+
+import "os"
+
+func socketCount() (int, error) {
+	sockstat, err := os.ReadFile("/proc/net/sockstat")
+	if err == nil {
+		if count, parseErr := parseSocketCount(sockstat); parseErr == nil {
+			return count, nil
+		}
+	}
+
+	// Preserve the old behaviour on unusual Linux environments without procfs.
+	return portableSocketCount()
+}

--- a/internal/web/socketcount_other.go
+++ b/internal/web/socketcount_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package web
+
+func socketCount() (int, error) {
+	return portableSocketCount()
+}

--- a/internal/web/socketcount_test.go
+++ b/internal/web/socketcount_test.go
@@ -1,0 +1,27 @@
+package web
+
+import "testing"
+
+func TestParseSocketCount(t *testing.T) {
+	sockstat := []byte("sockets: used 317\nTCP: inuse 12 orphan 0 tw 3 alloc 15 mem 1\nUDP: inuse 2 mem 1\n")
+
+	count, err := parseSocketCount(sockstat)
+	if err != nil {
+		t.Fatalf("parseSocketCount returned an error: %v", err)
+	}
+	if count != 317 {
+		t.Fatalf("parseSocketCount = %d, want 317", count)
+	}
+}
+
+func TestParseSocketCountRejectsInvalidInput(t *testing.T) {
+	for _, input := range []string{
+		"TCP: inuse 12\n",
+		"sockets: used nope\n",
+		"sockets: used -1\n",
+	} {
+		if _, err := parseSocketCount([]byte(input)); err == nil {
+			t.Fatalf("parseSocketCount(%q) unexpectedly succeeded", input)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- bound automatic SMUX session growth by a 128 MiB aggregate receive-window budget while preserving explicitly configured initial pools
- enforce the derived cap across WSSMUX, TCPMUX, and KCP even when pool and control-channel dials race
- use /proc/net/sockstat for the Linux socket total instead of allocating every gopsutil connection record
- reuse HTTP server buffers for WebSocket upgrades instead of retaining two additional 16 KiB buffers per connection

## Why
The Turbo preset could grow from 8 sessions with 16 MiB receive windows to 32 sessions, exposing the process to roughly 512 MiB of SMUX receive buffers. The new calculation preserves the historical default maximum footprint and prevents larger presets from silently multiplying it.

## Testing
- go test internal/client/transport/poolload.go internal/client/transport/poolload_test.go
- go test -count=100 internal/client/transport/poolload.go internal/client/transport/poolload_test.go
- go test ./internal/web
- GOOS=linux GOARCH=amd64 go build ./...
- GOOS=linux GOARCH=amd64 go test -c ./internal/client/transport and ./internal/web
- GOOS=linux GOARCH=arm64 go build ./...

A native Windows build of internal/client/transport remains blocked by existing Linux-specific syscall code in internal/utils/network; the Linux target builds successfully.
