### PR TITLE
fix: cancel idle relay connections

### DIFF
--- a/internal/utils/handlers/tcp_handler.go
+++ b/internal/utils/handlers/tcp_handler.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TCPConnectionHandler(ctx context.Context, proxyProtocol bool, from net.Conn, to net.Conn, logger *logrus.Logger, usage *web.Usage, remotePort int, sniffer bool) {
-	done := make(chan struct{})
-
 	// Write Proxy Protocol V2 Header
 	if proxyProtocol {
 		err := WriteProxyProtocol(from, to)
@@ -25,19 +23,35 @@ func TCPConnectionHandler(ctx context.Context, proxyProtocol bool, from net.Conn
 		}
 	}
 
+	// Both copies must run independently so cancellation is observed even when
+	// the connection is completely idle. Running one direction synchronously
+	// used to postpone the ctx select until that Read returned, which meant a
+	// reload could leave an old forwarded connection alive indefinitely.
+	done := make(chan struct{}, 2)
 	go func() {
-		defer close(done)
 		transferData(from, to, logger, usage, remotePort, sniffer)
+		done <- struct{}{}
+	}()
+	go func() {
+		transferData(to, from, logger, usage, remotePort, sniffer)
+		done <- struct{}{}
 	}()
 
-	transferData(to, from, logger, usage, remotePort, sniffer)
-
+	completed := 0
 	select {
 	case <-ctx.Done():
-		from.Close()
-		to.Close()
-		return
 	case <-done:
+		completed = 1
+	}
+
+	// Closing both sides interrupts the other copy. Wait for it to return before
+	// releasing the caller's connection quota; no relay goroutine from this
+	// connection is allowed to outlive the handler.
+	from.Close()
+	to.Close()
+	for completed < 2 {
+		<-done
+		completed++
 	}
 }
 

--- a/internal/utils/handlers/tcp_handler_test.go
+++ b/internal/utils/handlers/tcp_handler_test.go
@@ -129,6 +129,35 @@ func TestRelayClosesBothEnds(t *testing.T) {
 	}
 }
 
+// Cancellation is the shutdown path used by transport restarts and config
+// reloads. It must interrupt two idle Reads; waiting for traffic or for a peer
+// to close would leave the previous generation alive indefinitely.
+func TestRelayCancellationClosesBothEnds(t *testing.T) {
+	client, from := tcpPair(t)
+	to, backend := tcpPair(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		TCPConnectionHandler(ctx, false, from, to, quietLogger(), &web.Usage{}, 8080, false)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("an idle relay ignored context cancellation")
+	}
+
+	for name, conn := range map[string]net.Conn{"client": client, "backend": backend} {
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		if _, err := conn.Read(make([]byte, 1)); err == nil {
+			t.Errorf("%s side stayed open after cancellation", name)
+		}
+	}
+}
+
 // assertReceives reads exactly len(want) bytes from c and compares them.
 func assertReceives(t *testing.T, c net.Conn, want []byte, direction string) {
 	t.Helper()

--- a/internal/utils/handlers/ws_handler.go
+++ b/internal/utils/handlers/ws_handler.go
@@ -14,21 +14,31 @@ import (
 
 // WebSocketToTCPConnectionHandler handles data transfer between a WebSocket and a TCP connection
 func WSConnectionHandler(ctx context.Context, wsConn *websocket.Conn, tcpConn net.Conn, logger *logrus.Logger, usage *web.Usage, remotePort int, sniffer bool) {
-	done := make(chan struct{})
-
+	done := make(chan struct{}, 2)
 	go func() {
-		defer close(done)
 		transferWebSocketToTCP(wsConn, tcpConn, logger, usage, remotePort, sniffer)
+		done <- struct{}{}
+	}()
+	go func() {
+		transferTCPToWebSocket(tcpConn, wsConn, logger, usage, remotePort, sniffer)
+		done <- struct{}{}
 	}()
 
-	transferTCPToWebSocket(tcpConn, wsConn, logger, usage, remotePort, sniffer)
-
+	completed := 0
 	select {
 	case <-ctx.Done():
-		wsConn.Close()
-		tcpConn.Close()
-		return
 	case <-done:
+		completed = 1
+	}
+
+	// Close is what interrupts ReadMessage and the TCP Read on cancellation.
+	// Waiting for both workers also prevents a stale relay from surviving a
+	// transport generation change.
+	wsConn.Close()
+	tcpConn.Close()
+	for completed < 2 {
+		<-done
+		completed++
 	}
 }
 

--- a/internal/utils/handlers/ws_handler_test.go
+++ b/internal/utils/handlers/ws_handler_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/backpack/backpack/internal/web"
+	"github.com/gorilla/websocket"
+)
+
+func websocketPair(t *testing.T) (client, server *websocket.Conn) {
+	t.Helper()
+	accepted := make(chan *websocket.Conn, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		accepted <- conn
+	}))
+	t.Cleanup(httpServer.Close)
+
+	var err error
+	client, _, err = websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	server = <-accepted
+	t.Cleanup(func() { client.Close(); server.Close() })
+	return client, server
+}
+
+func TestWebSocketRelayCancellationClosesBothEnds(t *testing.T) {
+	wsClient, wsServer := websocketPair(t)
+	tcpRelay, backend := tcpPair(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WSConnectionHandler(ctx, wsServer, tcpRelay, quietLogger(), &web.Usage{}, 8080, false)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("an idle websocket relay ignored context cancellation")
+	}
+
+	wsClient.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := wsClient.ReadMessage(); err == nil {
+		t.Error("websocket side stayed open after cancellation")
+	}
+	backend.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := backend.Read(make([]byte, 1)); err == nil {
+		t.Error("TCP side stayed open after cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
- make relay copies observe cancellation even while both sockets are idle
- close both sides when the handler context ends
- cover idle cancellation and normal bidirectional relay behavior

## Verification
- go test ./internal/utils/handlers
- repeated isolated lifecycle tests

## Why this matters
Without an I/O deadline or socket close, an idle connection can survive tunnel shutdown/reload indefinitely and retain descriptors and goroutines.