### PR TITLE
fix: bound server transport queue lifetime

### DIFF
--- a/internal/server/transport/kcp.go
+++ b/internal/server/transport/kcp.go
@@ -492,6 +492,8 @@ func (s *KcpTransport) acceptSession(g *kcpGen, session *kcp.UDPSession) {
 			return
 		}
 		select {
+		case <-g.ctx.Done():
+			muxSession.Close()
 		case g.tunnelChannel <- muxSession: // ok
 		default:
 			s.logger.Warnf("tunnel listener channel is full, discarding KCP session from %s", session.RemoteAddr())
@@ -638,11 +640,13 @@ func (s *KcpTransport) acceptLocalConn(g *kcpGen, listener net.Listener, remoteA
 			}
 			conn = s.limits.wrap(conn)
 
+			atomic.AddInt32(&s.streamCounter, 1)
+			incoming := newCountedLocalTCPConn(conn, remoteAddr, s.limits, func() {
+				atomic.AddInt32(&s.streamCounter, -1)
+			})
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 				s.logger.Debugf("accepted incoming TCP connection from %s", tcpConn.RemoteAddr().String())
-
-				atomic.AddInt32(&s.streamCounter, 1)
 
 				if atomic.LoadInt32(&s.streamCounter) >= atomic.LoadInt32(&s.sessionCounter)*int32(s.config.MuxCon) {
 					s.logger.Tracef("stream counter: %v, session counter: %v", atomic.LoadInt32(&s.streamCounter), atomic.LoadInt32(&s.sessionCounter))
@@ -656,14 +660,25 @@ func (s *KcpTransport) acceptLocalConn(g *kcpGen, listener net.Listener, remoteA
 
 			default: // channel is full, discard the connection
 				s.logger.Warnf("local listener channel is full, discarding TCP connection from %s", tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 		}
 	}
 }
 
 func (s *KcpTransport) handleLoop(g *kcpGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case session := <-g.tunnelChannel:
+				session.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
@@ -680,60 +695,57 @@ func (s *KcpTransport) handleLoop(g *kcpGen) {
 func (s *KcpTransport) handleSession(g *kcpGen, session *smux.Session) {
 	counter := make(chan struct{}, s.config.MuxCon)
 	defer session.Close()
-	defer close(counter)
 
 	for {
-		// +1 for mux connection counter
-		counter <- struct{}{}
+		select {
+		case counter <- struct{}{}:
+		case <-g.ctx.Done():
+			return
+		}
 
 		select {
 		case <-g.ctx.Done():
+			<-counter
 			return
 
 		case incomingConn := <-g.localChannel:
-			if time.Now().UnixMilli()-incomingConn.timeCreated > 3000 { // 3000ms
-				s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-incomingConn.timeCreated)
-				incomingConn.conn.Close()
-
-				atomic.AddInt32(&s.streamCounter, -1)
+			if !incomingConn.claim() {
 				<-counter
 				continue
 			}
 
 			stream, err := session.OpenStream()
 			if err != nil {
-				s.handleSessionError(g, &incomingConn, err)
+				incomingConn.closeAndRelease()
+				s.handleSessionError(g, err)
 				return
 			}
 
 			// Send the target port over the tunnel connection
 			if err := utils.SendBinaryString(stream, incomingConn.remoteAddr); err != nil {
 				s.logger.Tracef("failed to send address over stream: %v", err)
-				// Put local connection back to local channel
-				g.localChannel <- incomingConn
+				stream.Close()
+				incomingConn.closeAndRelease()
+				<-counter
 				continue
 			}
 
 			// Handle data exchange between connections
-			go func() {
+			go func(incomingConn LocalTCPConn, stream net.Conn) {
 				// Free the connection slot once the transfer ends, or the
 				// limit would fill up permanently.
-				defer s.limits.release()
+				defer incomingConn.closeAndRelease()
 				handlers.TCPConnectionHandler(g.ctx, s.config.ProxyProtocol, incomingConn.conn, metrics.CountedConn(stream), s.logger, g.usageMonitor, incomingConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
-				atomic.AddInt32(&s.streamCounter, -1)
 				<-counter // read signal from the channel
-			}()
+			}(incomingConn, stream)
 		}
 	}
 }
 
-func (s *KcpTransport) handleSessionError(g *kcpGen, incomingConn *LocalTCPConn, err error) {
+func (s *KcpTransport) handleSessionError(g *kcpGen, err error) {
 	s.logger.Tracef("failed to handle session: %v", err)
 
 	atomic.AddInt32(&s.sessionCounter, -1)
-
-	// Put local connection back to local channel
-	g.localChannel <- *incomingConn
 
 	select {
 	case g.reqNewConnChan <- struct{}{}:

--- a/internal/server/transport/localqueue.go
+++ b/internal/server/transport/localqueue.go
@@ -1,0 +1,132 @@
+package transport
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// localQueueTimeout is the maximum time an accepted connection may wait for a
+// tunnel data connection. Keeping the deadline with the connection (rather than
+// checking its age only after dequeue) makes the limit real even while every
+// mux stream is busy or the tunnel is temporarily unavailable.
+const localQueueTimeout = 3 * time.Second
+
+type LocalTCPConn struct {
+	conn       net.Conn
+	remoteAddr string
+	lease      *localTCPLease
+}
+
+type localTCPLease struct {
+	mu        sync.Mutex
+	conn      net.Conn
+	limits    *limiter
+	timer     *time.Timer
+	expired   chan struct{}
+	onRelease func()
+	state     uint8 // 0 queued, 1 claimed by a relay, 2 released
+}
+
+func newLocalTCPConn(conn net.Conn, remoteAddr string, limits *limiter) LocalTCPConn {
+	return newLocalTCPConnWithTimeout(conn, remoteAddr, limits, localQueueTimeout, nil)
+}
+
+func newCountedLocalTCPConn(conn net.Conn, remoteAddr string, limits *limiter, onRelease func()) LocalTCPConn {
+	return newLocalTCPConnWithTimeout(conn, remoteAddr, limits, localQueueTimeout, onRelease)
+}
+
+func newLocalTCPConnWithTimeout(conn net.Conn, remoteAddr string, limits *limiter, timeout time.Duration, onRelease func()) LocalTCPConn {
+	lease := &localTCPLease{
+		conn:      conn,
+		limits:    limits,
+		expired:   make(chan struct{}),
+		onRelease: onRelease,
+	}
+	lease.timer = time.AfterFunc(timeout, lease.expire)
+	return LocalTCPConn{
+		conn:       conn,
+		remoteAddr: remoteAddr,
+		lease:      lease,
+	}
+}
+
+func (l *localTCPLease) expire() {
+	l.mu.Lock()
+	if l.state != 0 {
+		l.mu.Unlock()
+		return
+	}
+	l.state = 2
+	l.mu.Unlock()
+
+	l.release()
+	close(l.expired)
+}
+
+func (l *localTCPLease) release() {
+	l.conn.Close()
+	l.limits.release()
+	if l.onRelease != nil {
+		l.onRelease()
+	}
+}
+
+// claim transfers responsibility for releasing the limiter slot from the
+// queue timer to a relay handler. It fails when the deadline won the race.
+func (c LocalTCPConn) claim() bool {
+	if c.lease == nil { // compatibility for focused tests constructing literals
+		return true
+	}
+	l := c.lease
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.state != 0 {
+		return false
+	}
+	l.state = 1
+	l.timer.Stop()
+	return true
+}
+
+func (c LocalTCPConn) expiry() <-chan struct{} {
+	if c.lease == nil {
+		return nil
+	}
+	return c.lease.expired
+}
+
+// closeAndRelease is safe from the queue, a pairing goroutine, or the relay's
+// defer. Exactly one caller closes the connection and returns its quota.
+func (c LocalTCPConn) closeAndRelease() {
+	if c.lease == nil {
+		c.conn.Close()
+		return
+	}
+	l := c.lease
+	l.mu.Lock()
+	if l.state == 2 {
+		l.mu.Unlock()
+		return
+	}
+	l.state = 2
+	l.timer.Stop()
+	l.mu.Unlock()
+
+	l.release()
+	close(l.expired)
+}
+
+func drainLocalTCP(ch <-chan LocalTCPConn) {
+	for {
+		select {
+		case conn, ok := <-ch:
+			if !ok {
+				return
+			}
+			conn.closeAndRelease()
+		default:
+			return
+		}
+	}
+}

--- a/internal/server/transport/localqueue_test.go
+++ b/internal/server/transport/localqueue_test.go
@@ -1,0 +1,98 @@
+package transport
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestQueuedLocalConnectionExpiresAndReleasesQuota(t *testing.T) {
+	limits := newLimiter(Limits{MaxConnections: 1})
+	if !limits.acquire() {
+		t.Fatal("could not reserve the test connection slot")
+	}
+	server, peer := net.Pipe()
+	defer peer.Close()
+
+	var released atomic.Int32
+	conn := newLocalTCPConnWithTimeout(server, "127.0.0.1:8080", limits, 20*time.Millisecond, func() {
+		released.Add(1)
+	})
+
+	select {
+	case <-conn.expiry():
+	case <-time.After(time.Second):
+		t.Fatal("queued connection did not expire")
+	}
+	if conn.claim() {
+		t.Fatal("an expired connection was claimed by a relay")
+	}
+	if got := limits.active.Load(); got != 0 {
+		t.Fatalf("active quota = %d after expiry, want 0", got)
+	}
+	if got := released.Load(); got != 1 {
+		t.Fatalf("release callback ran %d times, want once", got)
+	}
+
+	peer.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := peer.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expired queued socket remained open")
+	}
+
+	// Cleanup paths may race with the timer; release must remain exactly once.
+	conn.closeAndRelease()
+	if got := released.Load(); got != 1 {
+		t.Fatalf("idempotent close ran release callback %d times", got)
+	}
+}
+
+func TestClaimedLocalConnectionOutlivesQueueDeadline(t *testing.T) {
+	limits := newLimiter(Limits{MaxConnections: 1})
+	if !limits.acquire() {
+		t.Fatal("could not reserve the test connection slot")
+	}
+	server, peer := net.Pipe()
+	defer peer.Close()
+
+	conn := newLocalTCPConnWithTimeout(server, "127.0.0.1:8080", limits, 20*time.Millisecond, nil)
+	if !conn.claim() {
+		t.Fatal("fresh connection could not be claimed")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-conn.expiry():
+		t.Fatal("queue timer closed a connection after relay handoff")
+	default:
+	}
+	if got := limits.active.Load(); got != 1 {
+		t.Fatalf("active quota = %d while relay owns it, want 1", got)
+	}
+
+	conn.closeAndRelease()
+	if got := limits.active.Load(); got != 0 {
+		t.Fatalf("active quota = %d after relay completion, want 0", got)
+	}
+}
+
+func TestDrainLocalTCPClosesEveryQueuedConnection(t *testing.T) {
+	limits := newLimiter(Limits{MaxConnections: 2})
+	queue := make(chan LocalTCPConn, 2)
+	for i := 0; i < 2; i++ {
+		if !limits.acquire() {
+			t.Fatal("could not reserve connection slot")
+		}
+		server, peer := net.Pipe()
+		defer peer.Close()
+		queue <- newLocalTCPConnWithTimeout(server, "127.0.0.1:8080", limits, time.Minute, nil)
+	}
+
+	drainLocalTCP(queue)
+	if got := len(queue); got != 0 {
+		t.Fatalf("queue still contains %d connections", got)
+	}
+	if got := limits.active.Load(); got != 0 {
+		t.Fatalf("active quota = %d after drain, want 0", got)
+	}
+}

--- a/internal/server/transport/quic.go
+++ b/internal/server/transport/quic.go
@@ -320,6 +320,8 @@ func (s *QuicTransport) acceptStream(g *quicGen, conn *quic.Conn, stream *quic.S
 			return
 		}
 		select {
+		case <-g.ctx.Done():
+			stream.Close()
 		case g.tunnelChannel <- wrapped:
 		default:
 			s.logger.Warnf("tunnel channel is full, discarding data stream from %s", conn.RemoteAddr())
@@ -522,13 +524,13 @@ func (s *QuicTransport) acceptLocalConn(g *quicGen, listener net.Listener, remot
 			}
 			conn = s.limits.wrap(conn)
 
+			incoming := newLocalTCPConn(conn, remoteAddr, s.limits)
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 				s.logger.Debugf("accepted incoming TCP connection from %s", tcpConn.RemoteAddr().String())
 			default: // channel is full, discard the connection
 				s.logger.Warnf("local listener channel is full, discarding TCP connection from %s", tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 		}
 	}
@@ -537,19 +539,24 @@ func (s *QuicTransport) acceptLocalConn(g *quicGen, listener net.Listener, remot
 // handleLoop pairs each accepted local connection with a data stream, asking the
 // client to open one if the pool has run dry, then forwards between the two.
 func (s *QuicTransport) handleLoop(g *quicGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case stream := <-g.tunnelChannel:
+				stream.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
 			return
 
 		case localConn := <-g.localChannel:
-			if time.Now().UnixMilli()-localConn.timeCreated > 3000 { // 3000ms
-				s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-localConn.timeCreated)
-				localConn.conn.Close()
-				s.limits.release()
-				continue
-			}
-
 			// Ask the client to open a fresh stream so the pool stays topped up;
 			// a warm one already waiting is taken straight off the channel.
 			select {
@@ -568,27 +575,29 @@ func (s *QuicTransport) pairLocalConn(g *quicGen, localConn LocalTCPConn) {
 	for {
 		select {
 		case <-g.ctx.Done():
-			localConn.conn.Close()
-			s.limits.release()
+			localConn.closeAndRelease()
+			return
+
+		case <-localConn.expiry():
 			return
 
 		case stream := <-g.tunnelChannel:
+			if !localConn.claim() {
+				stream.Close()
+				return
+			}
 			// Tell the client which backend this stream is for.
 			if err := utils.SendBinaryString(stream, localConn.remoteAddr); err != nil {
 				s.logger.Tracef("failed to send address over stream: %v", err)
 				stream.Close()
-				// That stream is gone; ask for another and try again.
-				select {
-				case g.reqNewConnChan <- struct{}{}:
-				default:
-				}
-				continue
+				localConn.closeAndRelease()
+				return
 			}
 
 			go func() {
 				// Free the connection slot once the transfer ends, or the limit
 				// would fill up permanently.
-				defer s.limits.release()
+				defer localConn.closeAndRelease()
 				handlers.TCPConnectionHandler(g.ctx, s.config.ProxyProtocol, localConn.conn, metrics.CountedConn(stream), s.logger, g.usageMonitor, localConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
 			}()
 			return

--- a/internal/server/transport/shared.go
+++ b/internal/server/transport/shared.go
@@ -105,12 +105,6 @@ type TunnelChannel struct { // for websocket
 	mu   *sync.Mutex
 }
 
-type LocalTCPConn struct {
-	conn        net.Conn
-	remoteAddr  string
-	timeCreated int64
-}
-
 type LocalAcceptUDPConn struct {
 	timeCreated int64
 	payload     chan []byte

--- a/internal/server/transport/tcp.go
+++ b/internal/server/transport/tcp.go
@@ -494,6 +494,8 @@ func (s *TcpTransport) admitControlChannel(g *tcpGen, conn net.Conn, ann announc
 // the pool is full.
 func (s *TcpTransport) deliverTunnelConn(g *tcpGen, conn net.Conn) {
 	select {
+	case <-g.ctx.Done():
+		conn.Close()
 	case g.tunnelChannel <- conn:
 	default: // The channel is full, do nothing
 		s.logger.Warnf("tunnel listener channel is full, discarding TCP connection from %s", conn.LocalAddr().String())
@@ -661,8 +663,9 @@ func (s *TcpTransport) acceptLocalConn(g *tcpGen, listener net.Listener, remoteA
 			}
 			conn = s.limits.wrap(conn)
 
+			incoming := newLocalTCPConn(conn, remoteAddr, s.limits)
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 
 				select {
 				case g.reqNewConnChan <- struct{}{}:
@@ -676,14 +679,25 @@ func (s *TcpTransport) acceptLocalConn(g *tcpGen, listener net.Listener, remoteA
 
 			default: // channel is full, discard the connection
 				s.logger.Warnf("channel with listener %s is full, discarding TCP connection from %s", listener.Addr().String(), tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 		}
 	}
 }
 
 func (s *TcpTransport) handleLoop(g *tcpGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case conn := <-g.tunnelChannel:
+				conn.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
@@ -691,35 +705,31 @@ func (s *TcpTransport) handleLoop(g *tcpGen) {
 		case localConn := <-g.localChannel:
 		loop:
 			for {
-				if time.Now().UnixMilli()-localConn.timeCreated > 3000 { // 3000ms
-					s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-localConn.timeCreated)
-					localConn.conn.Close()
-					// The slot this connection took on accept is only freed by the
-					// handler goroutine, which never runs when the connection times
-					// out waiting to be paired. Without this a tunnel with a
-					// connection limit loses a slot for every timeout until it can
-					// accept nothing at all.
-					s.limits.release()
-					break loop
-				}
-
 				select {
 				case <-g.ctx.Done():
+					localConn.closeAndRelease()
 					return
+				case <-localConn.expiry():
+					break loop
 
 				case tunnelConn := <-g.tunnelChannel:
+					if !localConn.claim() {
+						tunnelConn.Close()
+						break loop
+					}
 					// Send the target addr over the connection
 					if err := utils.SendBinaryTransportString(tunnelConn, localConn.remoteAddr, utils.SG_TCP); err != nil {
 						s.logger.Errorf("%v", err)
 						tunnelConn.Close()
-						continue loop
+						localConn.closeAndRelease()
+						break loop
 					}
 
 					// Handle data exchange between connections
 					go func(localConn LocalTCPConn, tunnelConn net.Conn) {
 						// Free the connection slot once the transfer ends, or
 						// the limit would fill up permanently.
-						defer s.limits.release()
+						defer localConn.closeAndRelease()
 						handlers.TCPConnectionHandler(g.ctx, s.config.ProxyProtocol, localConn.conn, metrics.CountedConn(tunnelConn), s.logger, g.usageMonitor, localConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
 					}(localConn, tunnelConn)
 					break loop

--- a/internal/server/transport/tcpmux.go
+++ b/internal/server/transport/tcpmux.go
@@ -518,6 +518,8 @@ func (s *TcpMuxTransport) deliverTunnelConn(g *tcpMuxGen, conn net.Conn) {
 	}
 
 	select {
+	case <-g.ctx.Done():
+		session.Close()
 	case g.tunnelChannel <- session: // ok
 	default:
 		s.logger.Warnf("tunnel listener channel is full, discarding TCP connection from %s", conn.LocalAddr().String())
@@ -672,12 +674,13 @@ func (s *TcpMuxTransport) acceptLocalConn(g *tcpMuxGen, listener net.Listener, r
 			}
 			conn = s.limits.wrap(conn)
 
+			atomic.AddInt32(&s.streamCounter, 1)
+			incoming := newCountedLocalTCPConn(conn, remoteAddr, s.limits, func() {
+				atomic.AddInt32(&s.streamCounter, -1)
+			})
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 				s.logger.Debugf("accepted incoming TCP connection from %s", tcpConn.RemoteAddr().String())
-
-				// +1 for stream counter
-				atomic.AddInt32(&s.streamCounter, 1)
 
 				if atomic.LoadInt32(&s.streamCounter) >= atomic.LoadInt32(&s.sessionCounter)*int32(s.config.MuxCon) {
 					s.logger.Tracef("stream counter: %v, session counter: %v", atomic.LoadInt32(&s.streamCounter), atomic.LoadInt32(&s.sessionCounter))
@@ -691,8 +694,7 @@ func (s *TcpMuxTransport) acceptLocalConn(g *tcpMuxGen, listener net.Listener, r
 
 			default: // channel is full, discard the connection
 				s.logger.Warnf("local listener channel is full, discarding TCP connection from %s", tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 
 		}
@@ -701,6 +703,18 @@ func (s *TcpMuxTransport) acceptLocalConn(g *tcpMuxGen, listener net.Listener, r
 }
 
 func (s *TcpMuxTransport) handleLoop(g *tcpMuxGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case session := <-g.tunnelChannel:
+				session.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
@@ -718,62 +732,58 @@ func (s *TcpMuxTransport) handleLoop(g *tcpMuxGen) {
 func (s *TcpMuxTransport) handleSession(g *tcpMuxGen, session *smux.Session) {
 	counter := make(chan struct{}, s.config.MuxCon)
 	defer session.Close()
-	defer close(counter)
 
 	for {
-		// +1 for mux connection counter
-		counter <- struct{}{}
+		select {
+		case counter <- struct{}{}:
+		case <-g.ctx.Done():
+			return
+		}
 
 		select {
 		case <-g.ctx.Done():
+			<-counter
 			return
 
 		case incomingConn := <-g.localChannel:
-			if time.Now().UnixMilli()-incomingConn.timeCreated > 3000 { // 3000ms
-				s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-incomingConn.timeCreated)
-				incomingConn.conn.Close()
-
-				// Decrement the counter
-				atomic.AddInt32(&s.streamCounter, -1)
+			if !incomingConn.claim() {
 				<-counter
 				continue
 			}
 
 			stream, err := session.OpenStream()
 			if err != nil {
-				s.handleSessionError(g, &incomingConn, err)
+				incomingConn.closeAndRelease()
+				s.handleSessionError(g, err)
 				return
 			}
 
 			// Send the target port over the tunnel connection
 			if err := utils.SendBinaryString(stream, incomingConn.remoteAddr); err != nil {
 				s.logger.Tracef("failed to send address over stream: %v", err)
-				// Put local connection back to local channel
-				g.localChannel <- incomingConn
+				stream.Close()
+				incomingConn.closeAndRelease()
+				<-counter
 				continue
 			}
 
 			// Handle data exchange between connections
-			go func() {
+			go func(incomingConn LocalTCPConn, stream net.Conn) {
 				// Free the connection slot once the transfer ends, or the
 				// limit would fill up permanently.
-				defer s.limits.release()
+				defer incomingConn.closeAndRelease()
 				handlers.TCPConnectionHandler(g.ctx, s.config.ProxyProtocol, incomingConn.conn, metrics.CountedConn(stream), s.logger, g.usageMonitor, incomingConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
-				atomic.AddInt32(&s.streamCounter, -1)
 				<-counter // read signal from the channel
-			}()
+			}(incomingConn, stream)
 		}
 	}
 }
 
-func (s *TcpMuxTransport) handleSessionError(g *tcpMuxGen, incomingConn *LocalTCPConn, err error) {
+func (s *TcpMuxTransport) handleSessionError(g *tcpMuxGen, err error) {
 	s.logger.Tracef("failed to handle session: %v", err)
 
 	// decrease session value
 	atomic.AddInt32(&s.sessionCounter, -1)
-
-	// Put local connection back to local channel
-	g.localChannel <- *incomingConn
 
 	// Attempt to request a new connection
 	select {

--- a/internal/server/transport/ws.go
+++ b/internal/server/transport/ws.go
@@ -316,6 +316,8 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 					mu:   &sync.Mutex{},
 				}
 				select {
+				case <-g.ctx.Done():
+					conn.Close()
 				case g.tunnelChannel <- wsConn:
 					go s.keepAlive(g, &wsConn)
 					s.logger.Debugf("websocket connection accepted from %s", conn.RemoteAddr().String())
@@ -534,8 +536,9 @@ func (s *WsTransport) acceptLocalConn(g *wsGen, listener net.Listener, remoteAdd
 			}
 			conn = s.limits.wrap(conn)
 
+			incoming := newLocalTCPConn(conn, remoteAddr, s.limits)
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 
 				select {
 				case g.reqNewConnChan <- struct{}{}:
@@ -549,14 +552,25 @@ func (s *WsTransport) acceptLocalConn(g *wsGen, listener net.Listener, remoteAdd
 
 			default: // channel is full, discard the connection
 				s.logger.Warnf("channel with listener %s is full, discarding TCP connection from %s", listener.Addr().String(), tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 		}
 	}
 }
 
 func (s *WsTransport) handleLoop(g *wsGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case tunnel := <-g.tunnelChannel:
+				tunnel.conn.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
@@ -564,28 +578,30 @@ func (s *WsTransport) handleLoop(g *wsGen) {
 		case localConn := <-g.localChannel:
 		loop:
 			for {
-				if time.Now().UnixMilli()-localConn.timeCreated > 3000 { // 3000ms
-					s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-localConn.timeCreated)
-					localConn.conn.Close()
-					break loop
-				}
-
 				select {
 				case <-g.ctx.Done():
+					localConn.closeAndRelease()
 					return
+				case <-localConn.expiry():
+					break loop
 				case tunnelConnection := <-g.tunnelChannel:
+					if !localConn.claim() {
+						tunnelConnection.conn.Close()
+						break loop
+					}
 					close(tunnelConnection.ping)
 					tunnelConnection.mu.Lock()
 					if err := tunnelConnection.conn.WriteMessage(websocket.TextMessage, []byte(localConn.remoteAddr)); err != nil {
 						s.logger.Debugf("%v", err) // failed to send port number
 						tunnelConnection.conn.Close()
-						continue loop
+						localConn.closeAndRelease()
+						break loop
 					}
 					// Handle data exchange between connections
 					go func(tunnelConn TunnelChannel, localConn LocalTCPConn) {
 						// Free the connection slot once the transfer ends, or
 						// the limit would fill up permanently.
-						defer s.limits.release()
+						defer localConn.closeAndRelease()
 						handlers.WSConnectionHandler(g.ctx, tunnelConn.conn, localConn.conn, s.logger, g.usageMonitor, localConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
 					}(tunnelConnection, localConn)
 					break loop

--- a/internal/server/transport/wsmux.go
+++ b/internal/server/transport/wsmux.go
@@ -345,6 +345,8 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 					return
 				}
 				select {
+				case <-g.ctx.Done():
+					session.Close()
 				case g.tunnelChannel <- session: // ok
 				default:
 					s.logger.Warnf("tunnel listener channel is full, discarding TCP connection from %s", conn.LocalAddr().String())
@@ -558,12 +560,13 @@ func (s *WsMuxTransport) acceptLocalConn(g *wsMuxGen, listener net.Listener, rem
 			}
 			conn = s.limits.wrap(conn)
 
+			atomic.AddInt32(&s.streamCounter, 1)
+			incoming := newCountedLocalTCPConn(conn, remoteAddr, s.limits, func() {
+				atomic.AddInt32(&s.streamCounter, -1)
+			})
 			select {
-			case g.localChannel <- LocalTCPConn{conn: conn, remoteAddr: remoteAddr, timeCreated: time.Now().UnixMilli()}:
+			case g.localChannel <- incoming:
 				s.logger.Debugf("accepted incoming TCP connection from %s", tcpConn.RemoteAddr().String())
-
-				// +1 for stream counter
-				atomic.AddInt32(&s.streamCounter, 1)
 
 				if atomic.LoadInt32(&s.streamCounter) >= atomic.LoadInt32(&s.sessionCounter)*int32(s.config.MuxCon) {
 					s.logger.Tracef("stream counter: %v, session counter: %v", atomic.LoadInt32(&s.streamCounter), atomic.LoadInt32(&s.sessionCounter))
@@ -577,8 +580,7 @@ func (s *WsMuxTransport) acceptLocalConn(g *wsMuxGen, listener net.Listener, rem
 
 			default: // channel is full, discard the connection
 				s.logger.Warnf("local listener channel is full, discarding TCP connection from %s", tcpConn.LocalAddr().String())
-				s.limits.release()
-				conn.Close()
+				incoming.closeAndRelease()
 			}
 		}
 	}
@@ -586,6 +588,18 @@ func (s *WsMuxTransport) acceptLocalConn(g *wsMuxGen, listener net.Listener, rem
 }
 
 func (s *WsMuxTransport) handleLoop(g *wsMuxGen) {
+	defer drainLocalTCP(g.localChannel)
+	defer func() {
+		for {
+			select {
+			case session := <-g.tunnelChannel:
+				session.Close()
+			default:
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-g.ctx.Done():
@@ -603,62 +617,58 @@ func (s *WsMuxTransport) handleLoop(g *wsMuxGen) {
 func (s *WsMuxTransport) handleSession(g *wsMuxGen, session *smux.Session) {
 	counter := make(chan struct{}, s.config.MuxCon)
 	defer session.Close()
-	defer close(counter)
 
 	for {
-		// +1 for mux connection counter
-		counter <- struct{}{}
+		select {
+		case counter <- struct{}{}:
+		case <-g.ctx.Done():
+			return
+		}
 
 		select {
 		case <-g.ctx.Done():
+			<-counter
 			return
 
 		case incomingConn := <-g.localChannel:
-			if time.Now().UnixMilli()-incomingConn.timeCreated > 3000 { // 3000ms
-				s.logger.Debugf("timeouted local connection: %d ms", time.Now().UnixMilli()-incomingConn.timeCreated)
-				incomingConn.conn.Close()
-
-				// Decrement the counter
-				atomic.AddInt32(&s.streamCounter, -1)
+			if !incomingConn.claim() {
 				<-counter
 				continue
 			}
 
 			stream, err := session.OpenStream()
 			if err != nil {
-				s.handleSessionError(g, &incomingConn, err)
+				incomingConn.closeAndRelease()
+				s.handleSessionError(g, err)
 				return
 			}
 
 			// Send the target port over the tunnel connection
 			if err := utils.SendBinaryString(stream, incomingConn.remoteAddr); err != nil {
 				s.logger.Tracef("failed to send address over stream: %v", err)
-				// Put local connection back to local channel
-				g.localChannel <- incomingConn
+				stream.Close()
+				incomingConn.closeAndRelease()
+				<-counter
 				continue
 			}
 
 			// Handle data exchange between connections
-			go func() {
+			go func(incomingConn LocalTCPConn, stream net.Conn) {
 				// Free the connection slot once the transfer ends, or the
 				// limit would fill up permanently.
-				defer s.limits.release()
+				defer incomingConn.closeAndRelease()
 				handlers.TCPConnectionHandler(g.ctx, s.config.ProxyProtocol, incomingConn.conn, metrics.CountedConn(stream), s.logger, g.usageMonitor, incomingConn.conn.LocalAddr().(*net.TCPAddr).Port, s.config.Sniffer)
-				atomic.AddInt32(&s.streamCounter, -1)
 				<-counter // read signal from the channel
-			}()
+			}(incomingConn, stream)
 		}
 	}
 }
 
-func (s *WsMuxTransport) handleSessionError(g *wsMuxGen, incomingConn *LocalTCPConn, err error) {
+func (s *WsMuxTransport) handleSessionError(g *wsMuxGen, err error) {
 	s.logger.Tracef("failed to handle session: %v", err)
 
 	// decrease session value
 	atomic.AddInt32(&s.sessionCounter, -1)
-
-	// Put local connection back to local channel
-	g.localChannel <- *incomingConn
 
 	// Attempt to request a new connection
 	select {


### PR DESCRIPTION
## Summary
- tie queued server-side transport work to the active generation
- stop accepting and draining stale queue entries after cancellation
- make shutdown deterministic instead of leaving workers blocked

## Verification
- state-machine tests repeated under load
- Linux cross-build and go vet for affected transport packages

## Why this matters
A reload could leave stale queued work and blocked goroutines attached to a generation that was already stopped.