### PR TITLE
fix: stop client generations deterministically

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/backpack/backpack/internal/utils"
@@ -21,10 +22,13 @@ import (
 
 // Client encapsulates the client configuration and state
 type Client struct {
-	config *config.ClientConfig
-	ctx    context.Context
-	cancel context.CancelFunc
-	logger *logrus.Logger
+	config  *config.ClientConfig
+	ctx     context.Context
+	cancel  context.CancelFunc
+	logger  *logrus.Logger
+	started chan struct{}
+	done    chan struct{}
+	start   sync.Once
 }
 
 func NewClient(cfg *config.ClientConfig, parentCtx context.Context) *Client {
@@ -35,15 +39,21 @@ func NewClient(cfg *config.ClientConfig, parentCtx context.Context) *Client {
 	// Off unless this tunnel asked for it; see handlers/zerocopy.go.
 	handlers.SetZeroCopy(cfg.ZeroCopy)
 	return &Client{
-		config: cfg,
-		ctx:    ctx,
-		cancel: cancel,
-		logger: utils.NewLoggerWithFormat(cfg.LogLevel, cfg.LogFormat),
+		config:  cfg,
+		ctx:     ctx,
+		cancel:  cancel,
+		logger:  utils.NewLoggerWithFormat(cfg.LogLevel, cfg.LogFormat),
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
 	}
 }
 
 // Run starts the client and begins dialing the tunnel server
 func (c *Client) Start() {
+	c.start.Do(func() { close(c.started) })
+	defer close(c.done)
+	var stop func()
+	var wait func()
 	// Profiling endpoint, off unless explicitly enabled in the config. Bound to
 	// loopback: pprof is unauthenticated and its heap dump would expose the
 	// tunnel token. Reach it with `ssh -L 6061:127.0.0.1:6061 root@server`.
@@ -109,7 +119,8 @@ func (c *Client) Start() {
 			Stealth: c.config.Transport == config.STEALTH,
 		}
 		tcpClient := transport.NewTCPClient(c.ctx, tcpConfig, c.logger)
-		go tcpClient.Start()
+		tcpClient.Start()
+		stop, wait = tcpClient.Stop, tcpClient.Wait
 
 	case config.TCPMUX:
 		tcpMuxConfig := &transport.TcpMuxConfig{
@@ -135,7 +146,8 @@ func (c *Client) Start() {
 			Outbound:         outbound,
 		}
 		tcpMuxClient := transport.NewMuxClient(c.ctx, tcpMuxConfig, c.logger)
-		go tcpMuxClient.Start()
+		tcpMuxClient.Start()
+		stop, wait = tcpMuxClient.Stop, tcpMuxClient.Wait
 
 	case config.KCP, config.XDI, config.SPOOF:
 		// The spoof transport in pipe mode is a bare datagram relay for
@@ -165,7 +177,9 @@ func (c *Client) Start() {
 				PipeAddr: pipeAddr,
 				Retry:    time.Duration(c.config.RetryInterval) * time.Second,
 			}
-			go transport.NewSpoofPipeClient(c.ctx, pipeCfg, c.logger).Start()
+			pipeClient := transport.NewSpoofPipeClient(c.ctx, pipeCfg, c.logger)
+			go pipeClient.Start()
+			stop, wait = pipeClient.Stop, pipeClient.Wait
 			break
 		}
 
@@ -211,7 +225,8 @@ func (c *Client) Start() {
 			SpoofInterface:   c.config.SpoofInterface,
 		}
 		kcpClient := transport.NewKcpClient(c.ctx, kcpConfig, c.logger)
-		go kcpClient.Start()
+		kcpClient.Start()
+		stop, wait = kcpClient.Stop, kcpClient.Wait
 
 	case config.QUIC:
 		quicConfig := &transport.QuicConfig{
@@ -230,7 +245,8 @@ func (c *Client) Start() {
 			SO_SNDBUF:      c.config.SO_SNDBUF,
 		}
 		quicClient := transport.NewQuicClient(c.ctx, quicConfig, c.logger)
-		go quicClient.Start()
+		quicClient.Start()
+		stop, wait = quicClient.Stop, quicClient.Wait
 
 	case config.WS, config.WSS:
 		WsConfig := &transport.WsConfig{
@@ -252,7 +268,8 @@ func (c *Client) Start() {
 			Outbound:       outbound,
 		}
 		WsClient := transport.NewWSClient(c.ctx, WsConfig, c.logger)
-		go WsClient.Start()
+		WsClient.Start()
+		stop, wait = WsClient.Stop, WsClient.Wait
 
 	case config.WSMUX, config.WSSMUX:
 		wsMuxConfig := &transport.WsMuxConfig{
@@ -278,7 +295,8 @@ func (c *Client) Start() {
 			Outbound:         outbound,
 		}
 		wsMuxClient := transport.NewWSMuxClient(c.ctx, wsMuxConfig, c.logger)
-		go wsMuxClient.Start()
+		wsMuxClient.Start()
+		stop, wait = wsMuxClient.Stop, wsMuxClient.Wait
 
 	case config.UDP:
 		udpConfig := &transport.UdpConfig{
@@ -296,13 +314,18 @@ func (c *Client) Start() {
 			SO_SNDBUF:      c.config.SO_SNDBUF,
 		}
 		udpClient := transport.NewUDPClient(c.ctx, udpConfig, c.logger)
-		go udpClient.Start()
+		udpClient.Start()
+		stop, wait = udpClient.Stop, udpClient.Wait
 
 	default:
 		c.logger.Fatal("invalid transport type: ", c.config.Transport)
 	}
 
 	<-c.ctx.Done()
+	if stop != nil {
+		stop()
+		wait()
+	}
 
 	c.logger.Info("all workers stopped successfully")
 
@@ -312,6 +335,11 @@ func (c *Client) Start() {
 func (c *Client) Stop() {
 	if c.cancel != nil {
 		c.cancel()
+	}
+	select {
+	case <-c.started:
+		<-c.done
+	default:
 	}
 }
 

--- a/internal/client/transport/accept_udp.go
+++ b/internal/client/transport/accept_udp.go
@@ -2,9 +2,11 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/backpack/backpack/internal/web"
@@ -13,7 +15,7 @@ import (
 
 const BufferSize = 16 * 1024
 
-func UDPDialer(tcp net.Conn, remoteAddr string, logger *logrus.Logger, usage *web.Usage, remotePort int, sniffer bool) {
+func UDPDialer(ctx context.Context, tcp net.Conn, remoteAddr string, logger *logrus.Logger, usage *web.Usage, remotePort int, sniffer bool) {
 	remoteUDPAddr, err := net.ResolveUDPAddr("udp", remoteAddr)
 	if err != nil {
 		// One flow's bad target must not take the whole client down: drop this
@@ -30,6 +32,22 @@ func UDPDialer(tcp net.Conn, remoteAddr string, logger *logrus.Logger, usage *we
 	}
 
 	defer remoteConn.Close()
+	stop := make(chan struct{})
+	var stopWG sync.WaitGroup
+	stopWG.Add(1)
+	defer func() {
+		close(stop)
+		stopWG.Wait()
+	}()
+	go func() {
+		defer stopWG.Done()
+		select {
+		case <-ctx.Done():
+			remoteConn.Close()
+			tcp.Close()
+		case <-stop:
+		}
+	}()
 
 	done := make(chan struct{})
 

--- a/internal/client/transport/kcp.go
+++ b/internal/client/transport/kcp.go
@@ -156,13 +156,17 @@ func NewKcpClient(parentCtx context.Context, config *KcpConfig, logger *logrus.L
 
 func (c *KcpTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = "Disconnected (" + c.transportLabel() + ")"
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *KcpTransport) Stop() { c.state.Stop() }
+func (c *KcpTransport) Wait() { c.state.Wait() }
 
 func (c *KcpTransport) Restart() {
 	if !c.restartMutex.TryLock() {
@@ -177,13 +181,7 @@ func (c *KcpTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -214,7 +212,7 @@ func (c *KcpTransport) Restart() {
 
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 }
 
 // dial opens one KCP session.
@@ -302,13 +300,15 @@ func (c *KcpTransport) channelDialer() {
 				continue
 			}
 
-			c.state.SetConn(tunnelConn)
+			if !c.state.SetConn(tunnelConn) {
+				return
+			}
 			c.logger.Info("control channel established successfully")
 
 			c.config.TunnelStatus = "Connected (" + c.transportLabel() + ")"
 
-			go c.poolMaintainer()
-			go c.channelHandler()
+			c.state.Go(c.poolMaintainer)
+			c.state.Go(c.channelHandler)
 
 			return
 		}
@@ -317,7 +317,7 @@ func (c *KcpTransport) channelDialer() {
 
 func (c *KcpTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { // initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -379,7 +379,7 @@ func (c *KcpTransport) poolMaintainer() {
 				c.logger.Debugf("increasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d, throughput: %d Mbit/s", newPoolSize, newPoolSize+1, poolConnectionsAvg, loadConnections, mbps)
 				newPoolSize++
 
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -404,7 +404,7 @@ func (c *KcpTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryByte
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -422,7 +422,7 @@ func (c *KcpTransport) channelHandler() {
 				}
 				msg, err := utils.ReceiveBinaryByte(c.state.Conn())
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 							c.logger.Warn("no heartbeat from the server within the keepalive period, reconnecting")
 						} else {
@@ -435,7 +435,7 @@ func (c *KcpTransport) channelHandler() {
 				msgChan <- msg
 			}
 		}
-	}()
+	})
 
 	for {
 		select {
@@ -453,7 +453,7 @@ func (c *KcpTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -482,6 +482,11 @@ func (c *KcpTransport) tunnelDialer() {
 		c.logger.Errorf("tunnel server dialer: %v", err)
 		return
 	}
+	untrack, ok := c.state.Track(tunnelConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// KCP has no connection handshake of its own: the server's listener only
 	// materialises a session once it receives a packet from this socket. So
@@ -502,7 +507,6 @@ func (c *KcpTransport) handleSession(tunnelConn net.Conn) {
 	defer func() {
 		atomic.AddInt32(&c.poolConnections, -1)
 	}()
-
 	// SMUX server
 	session, err := smux.Server(tunnelConn, c.smuxConfig)
 	if err != nil {
@@ -510,6 +514,7 @@ func (c *KcpTransport) handleSession(tunnelConn net.Conn) {
 		tunnelConn.Close()
 		return
 	}
+	defer session.Close()
 
 	for {
 		select {
@@ -530,7 +535,10 @@ func (c *KcpTransport) handleSession(tunnelConn net.Conn) {
 				continue
 			}
 
-			go c.localDialer(stream, remoteAddr)
+			if !c.state.Go(func() { c.localDialer(stream, remoteAddr) }) {
+				stream.Close()
+				return
+			}
 		}
 	}
 }

--- a/internal/client/transport/quic.go
+++ b/internal/client/transport/quic.go
@@ -109,13 +109,24 @@ func (c *QuicTransport) getQUICConn() *quic.Conn {
 
 func (c *QuicTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = "Disconnected (QUIC)"
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *QuicTransport) Stop() {
+	c.state.Stop()
+	if qc := c.getQUICConn(); qc != nil {
+		_ = qc.CloseWithError(0, "client stopped")
+		c.setQUICConn(nil)
+	}
+}
+
+func (c *QuicTransport) Wait() { c.state.Wait() }
 
 func (c *QuicTransport) Restart() {
 	if !c.restartMutex.TryLock() {
@@ -130,19 +141,8 @@ func (c *QuicTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	c.state.CloseConn()
-	// Closing the QUIC connection tears down every stream it carries, including
-	// the pool, and releases the UDP socket underneath.
-	if qc := c.getQUICConn(); qc != nil {
-		_ = qc.CloseWithError(0, "restart")
-		c.setQUICConn(nil)
-	}
-
-	time.Sleep(2 * time.Second)
+	c.Stop()
+	c.Wait()
 
 	// The whole tunnel may have been shut down while this restart was waiting.
 	// Rebuilding from a finished parent context would bind and close for nothing.
@@ -163,7 +163,7 @@ func (c *QuicTransport) Restart() {
 
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 }
 
 func (c *QuicTransport) channelDialer() {
@@ -242,13 +242,17 @@ func (c *QuicTransport) channelDialer() {
 			}
 
 			c.setQUICConn(conn)
-			c.state.SetConn(control)
+			if !c.state.SetConn(control) {
+				_ = conn.CloseWithError(0, "generation stopped")
+				c.setQUICConn(nil)
+				return
+			}
 			c.logger.Info("control channel established successfully")
 
 			c.config.TunnelStatus = "Connected (QUIC)"
 
-			go c.poolMaintainer()
-			go c.channelHandler()
+			c.state.Go(c.poolMaintainer)
+			c.state.Go(c.channelHandler)
 
 			return
 		}
@@ -257,7 +261,7 @@ func (c *QuicTransport) channelDialer() {
 
 func (c *QuicTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { // initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -308,7 +312,7 @@ func (c *QuicTransport) poolMaintainer() {
 				c.logger.Debugf("increasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d, throughput: %d Mbit/s", newPoolSize, newPoolSize+1, poolConnectionsAvg, loadConnections, mbps)
 				newPoolSize++
 
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -332,7 +336,7 @@ func (c *QuicTransport) controlDeadline() time.Duration {
 func (c *QuicTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -348,7 +352,7 @@ func (c *QuicTransport) channelHandler() {
 				}
 				msg, err := utils.ReceiveBinaryByte(c.state.Conn())
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 							c.logger.Warn("no heartbeat from the server within the keepalive period, reconnecting")
 						} else {
@@ -361,7 +365,7 @@ func (c *QuicTransport) channelHandler() {
 				msgChan <- msg
 			}
 		}
-	}()
+	})
 
 	for {
 		select {
@@ -379,7 +383,7 @@ func (c *QuicTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -413,6 +417,11 @@ func (c *QuicTransport) tunnelDialer() {
 		return
 	}
 	data := network.NewQUICStreamConn(stream, qc)
+	untrack, ok := c.state.Track(data)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// Announce the stream with the token so the server can authenticate it and
 	// file it as a data stream.

--- a/internal/client/transport/spoofpipe.go
+++ b/internal/client/transport/spoofpipe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/backpack/backpack/internal/utils/network"
@@ -18,6 +19,7 @@ type SpoofPipeClient struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	logger *logrus.Logger
+	done   chan struct{}
 }
 
 // SpoofPipeConfig is shared by both ends. Carrier describes the spoof channel;
@@ -33,10 +35,11 @@ type SpoofPipeConfig struct {
 
 func NewSpoofPipeClient(parentCtx context.Context, config *SpoofPipeConfig, logger *logrus.Logger) *SpoofPipeClient {
 	ctx, cancel := context.WithCancel(parentCtx)
-	return &SpoofPipeClient{config: config, ctx: ctx, cancel: cancel, logger: logger}
+	return &SpoofPipeClient{config: config, ctx: ctx, cancel: cancel, logger: logger, done: make(chan struct{})}
 }
 
 func (c *SpoofPipeClient) Start() {
+	defer close(c.done)
 	retry := c.config.Retry
 	if retry <= 0 {
 		retry = 3 * time.Second
@@ -57,6 +60,7 @@ func (c *SpoofPipeClient) Start() {
 }
 
 func (c *SpoofPipeClient) Stop() { c.cancel() }
+func (c *SpoofPipeClient) Wait() { <-c.done }
 
 func (c *SpoofPipeClient) runOnce() error {
 	sa, err := net.ResolveIPAddr("ip4", c.config.ServerIP)
@@ -81,8 +85,14 @@ func (c *SpoofPipeClient) runOnce() error {
 
 	// Unblock the relay's reads when the run is cancelled.
 	stop := make(chan struct{})
-	defer close(stop)
+	var stopWG sync.WaitGroup
+	stopWG.Add(1)
+	defer func() {
+		close(stop)
+		stopWG.Wait()
+	}()
 	go func() {
+		defer stopWG.Done()
 		select {
 		case <-c.ctx.Done():
 		case <-stop:

--- a/internal/client/transport/state.go
+++ b/internal/client/transport/state.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 
@@ -9,28 +10,26 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// A client transport rebuilds its state on every reconnect: Restart() swaps the
-// context, the control channel, the usage monitor and the counters while the
-// previous generation's goroutines are still winding down. Those goroutines are
-// reading the very fields being replaced, which is a data race — and the values
-// involved are pointers and channels, where an unsynchronised read is not
-// merely stale but undefined.
-//
-// clientState puts that generation-scoped state behind one lock so a reader
-// always sees a complete, consistent generation.
-
-// clientState holds everything Restart() replaces.
+// clientState owns one complete transport generation. Restart stops and waits
+// for that generation before Reset publishes the next one, so an old worker can
+// never accidentally start reading the new generation's context or control
+// connection.
 type clientState struct {
 	mu           sync.RWMutex
 	ctx          context.Context
 	cancel       context.CancelFunc
-	conn         net.Conn        // control channel for the byte-stream transports
-	wsConn       *websocket.Conn // control channel for the websocket transports
+	conn         net.Conn
+	wsConn       *websocket.Conn
 	usageMonitor *web.Usage
+
+	workers  sync.WaitGroup
+	stopping bool
+	closers  map[uint64]io.Closer
+	nextID   uint64
 }
 
-// Reset publishes a whole new generation at once, so no reader can observe a
-// half-swapped mixture of old and new.
+// Reset publishes a new generation. The caller must StopAndWait first whenever
+// a previous generation has been started.
 func (s *clientState) Reset(ctx context.Context, cancel context.CancelFunc, usage *web.Usage) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -39,18 +38,15 @@ func (s *clientState) Reset(ctx context.Context, cancel context.CancelFunc, usag
 	s.usageMonitor = usage
 	s.conn = nil
 	s.wsConn = nil
+	s.stopping = false
+	s.closers = make(map[uint64]io.Closer)
+	s.nextID = 0
 }
 
 func (s *clientState) Ctx() context.Context {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.ctx
-}
-
-func (s *clientState) Cancel() context.CancelFunc {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.cancel
 }
 
 func (s *clientState) Usage() *web.Usage {
@@ -65,10 +61,17 @@ func (s *clientState) Conn() net.Conn {
 	return s.conn
 }
 
-func (s *clientState) SetConn(c net.Conn) {
+func (s *clientState) SetConn(c net.Conn) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.stopping {
+		s.mu.Unlock()
+		c.Close()
+		return false
+	}
 	s.conn = c
+	s.addCloserLocked(c)
+	s.mu.Unlock()
+	return true
 }
 
 func (s *clientState) WSConn() *websocket.Conn {
@@ -77,25 +80,102 @@ func (s *clientState) WSConn() *websocket.Conn {
 	return s.wsConn
 }
 
-func (s *clientState) SetWSConn(c *websocket.Conn) {
+func (s *clientState) SetWSConn(c *websocket.Conn) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.stopping {
+		s.mu.Unlock()
+		c.Close()
+		return false
+	}
 	s.wsConn = c
+	s.addCloserLocked(c)
+	s.mu.Unlock()
+	return true
 }
 
-// CloseConn closes whichever control channel is held, if any.
-func (s *clientState) CloseConn() {
-	if c := s.Conn(); c != nil {
-		c.Close()
+// Go starts a worker only while the generation is live. Add and Stop share the
+// same lock, which makes Wait safe: once Stop returns, no worker can be added.
+func (s *clientState) Go(fn func()) bool {
+	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
+		return false
 	}
-	if c := s.WSConn(); c != nil {
+	s.workers.Add(1)
+	s.mu.Unlock()
+
+	go func() {
+		defer s.workers.Done()
+		fn()
+	}()
+	return true
+}
+
+// Track registers a blocking connection or session for forced closure at
+// generation shutdown. The returned function removes resources which finish
+// normally. A connection that arrives after Stop is closed immediately.
+func (s *clientState) Track(c io.Closer) (untrack func(), ok bool) {
+	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
 		c.Close()
+		return func() {}, false
+	}
+	id := s.addCloserLocked(c)
+	s.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.mu.Lock()
+			delete(s.closers, id)
+			s.mu.Unlock()
+		})
+	}, true
+}
+
+func (s *clientState) addCloserLocked(c io.Closer) uint64 {
+	s.nextID++
+	s.closers[s.nextID] = c
+	return s.nextID
+}
+
+// Stop cancels the generation and closes every registered blocking resource.
+// Close calls happen outside the state lock because third-party implementations
+// are allowed to run callbacks while closing.
+func (s *clientState) Stop() {
+	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
+		return
+	}
+	s.stopping = true
+	cancel := s.cancel
+	closers := make([]io.Closer, 0, len(s.closers))
+	for _, c := range s.closers {
+		closers = append(closers, c)
+	}
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	for _, c := range closers {
+		_ = c.Close()
 	}
 }
 
-// drain empties a buffered signal channel without replacing it. Restart used to
-// allocate a new channel, which races with the goroutines selecting on the old
-// one; emptying the existing channel achieves the same thing safely.
+func (s *clientState) Wait() {
+	s.workers.Wait()
+}
+
+func (s *clientState) StopAndWait() {
+	s.Stop()
+	s.Wait()
+}
+
+// drain empties a buffered signal channel without replacing it. Replacing the
+// channel would strand workers which already selected on the old one.
 func drain(ch chan struct{}) {
 	for {
 		select {

--- a/internal/client/transport/state_test.go
+++ b/internal/client/transport/state_test.go
@@ -1,0 +1,92 @@
+package transport
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/xtaci/smux"
+)
+
+func newTestClientState(t *testing.T) (*clientState, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &clientState{}
+	s.Reset(ctx, cancel, nil)
+	return s, cancel
+}
+
+func TestClientStateStopClosesResourcesAndWaitsForWorkers(t *testing.T) {
+	s, cancel := newTestClientState(t)
+	defer cancel()
+	server, peer := net.Pipe()
+	defer peer.Close()
+
+	if _, ok := s.Track(server); !ok {
+		t.Fatal("live generation rejected a connection")
+	}
+	workerDone := make(chan struct{})
+	if !s.Go(func() {
+		defer close(workerDone)
+		_, _ = server.Read(make([]byte, 1))
+	}) {
+		t.Fatal("live generation rejected a worker")
+	}
+
+	s.StopAndWait()
+	select {
+	case <-workerDone:
+	default:
+		t.Fatal("StopAndWait returned before the blocked worker exited")
+	}
+	if s.Go(func() {}) {
+		t.Fatal("stopped generation accepted a new worker")
+	}
+}
+
+func TestClientStateStopUnblocksSMUXAccept(t *testing.T) {
+	s, cancel := newTestClientState(t)
+	defer cancel()
+	serverConn, peerConn := net.Pipe()
+	defer peerConn.Close()
+
+	session, err := smux.Server(serverConn, smux.DefaultConfig())
+	if err != nil {
+		t.Fatalf("create SMUX session: %v", err)
+	}
+	if _, ok := s.Track(serverConn); !ok {
+		t.Fatal("live generation rejected the SMUX connection")
+	}
+	accepted := make(chan error, 1)
+	s.Go(func() {
+		_, err := session.AcceptStream()
+		accepted <- err
+	})
+
+	s.StopAndWait()
+	select {
+	case err := <-accepted:
+		if err == nil {
+			t.Fatal("AcceptStream unexpectedly succeeded during shutdown")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("closing the generation did not unblock AcceptStream")
+	}
+}
+
+func TestClientStateTrackAfterStopClosesImmediately(t *testing.T) {
+	s, cancel := newTestClientState(t)
+	defer cancel()
+	s.StopAndWait()
+
+	server, peer := net.Pipe()
+	defer peer.Close()
+	if _, ok := s.Track(server); ok {
+		t.Fatal("stopped generation accepted a late connection")
+	}
+	peer.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := peer.Read(make([]byte, 1)); err == nil {
+		t.Fatal("late connection was not closed")
+	}
+}

--- a/internal/client/transport/tcp.go
+++ b/internal/client/transport/tcp.go
@@ -99,13 +99,18 @@ func NewTCPClient(parentCtx context.Context, config *TcpConfig, logger *logrus.L
 
 func (c *TcpTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = "Disconnected (TCP)"
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *TcpTransport) Stop() { c.state.Stop() }
+func (c *TcpTransport) Wait() { c.state.Wait() }
+
 func (c *TcpTransport) Restart() {
 	if !c.restartMutex.TryLock() {
 		c.logger.Warn("client is already restarting")
@@ -119,14 +124,9 @@ func (c *TcpTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	// close control channel connection
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	// Cancel the generation, close its control and pool connections, and wait
+	// until no old worker can observe the state published below.
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -161,7 +161,7 @@ func (c *TcpTransport) Restart() {
 	// set the log level again
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 }
 
 func (c *TcpTransport) channelDialer() {
@@ -244,12 +244,14 @@ func (c *TcpTransport) channelDialer() {
 				// Before the control channel is published, so the pool
 				// connections poolMaintainer starts below already have it.
 				c.poolNonce.Set(nonce)
-				c.state.SetConn(tunnelTCPConn)
+				if !c.state.SetConn(tunnelTCPConn) {
+					return
+				}
 				c.logger.Info("control channel established successfully")
 
 				c.config.TunnelStatus = "Connected (TCP)"
-				go c.poolMaintainer()
-				go c.channelHandler()
+				c.state.Go(c.poolMaintainer)
+				c.state.Go(c.channelHandler)
 
 				return
 
@@ -265,7 +267,7 @@ func (c *TcpTransport) channelDialer() {
 
 func (c *TcpTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -328,7 +330,7 @@ func (c *TcpTransport) poolMaintainer() {
 				newPoolSize++
 
 				// Add a new connection to the pool
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -345,7 +347,7 @@ func (c *TcpTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryString
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -353,7 +355,7 @@ func (c *TcpTransport) channelHandler() {
 			default:
 				msg, err := utils.ReceiveBinaryByte(c.state.Conn())
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						c.logger.Error("failed to read from control channel. ", err)
 						go c.Restart()
 					}
@@ -362,7 +364,7 @@ func (c *TcpTransport) channelHandler() {
 				msgChan <- msg
 			}
 		}
-	}()
+	})
 
 	// Main loop to listen for context cancellation or received messages
 	for {
@@ -381,7 +383,7 @@ func (c *TcpTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -432,6 +434,11 @@ func (c *TcpTransport) tunnelDialer() {
 		rawConn.Close()
 		return
 	}
+	untrack, ok := c.state.Track(tcpConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// Say what this connection is, so the server admits it on the nonce rather
 	// than on the address it happened to dial out from.
@@ -470,7 +477,7 @@ func (c *TcpTransport) tunnelDialer() {
 		c.localDialer(tcpConn, resolvedAddr, port)
 
 	case utils.SG_UDP:
-		UDPDialer(tcpConn, resolvedAddr, c.logger, c.state.Usage(), port, c.config.Sniffer)
+		UDPDialer(c.state.Ctx(), tcpConn, resolvedAddr, c.logger, c.state.Usage(), port, c.config.Sniffer)
 
 	default:
 		c.logger.Error("undefined transport. close the connection.")

--- a/internal/client/transport/tcpmux.go
+++ b/internal/client/transport/tcpmux.go
@@ -103,13 +103,17 @@ func NewMuxClient(parentCtx context.Context, config *TcpMuxConfig, logger *logru
 
 func (c *TcpMuxTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = "Disconnected (TCPMUX)"
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *TcpMuxTransport) Stop() { c.state.Stop() }
+func (c *TcpMuxTransport) Wait() { c.state.Wait() }
 
 func (c *TcpMuxTransport) Restart() {
 	if !c.restartMutex.TryLock() {
@@ -124,14 +128,7 @@ func (c *TcpMuxTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	// close control channel connection
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -167,7 +164,7 @@ func (c *TcpMuxTransport) Restart() {
 	// set the log level again
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 
 }
 
@@ -240,13 +237,15 @@ func (c *TcpMuxTransport) channelDialer() {
 				// Settled before the pool starts, so no session is ever built
 				// on a version the server has not confirmed.
 				c.setMuxVersion(muxVersion)
-				c.state.SetConn(tunnelConn)
+				if !c.state.SetConn(tunnelConn) {
+					return
+				}
 				c.logger.Infof("control channel established successfully (mux version %d)", c.muxVersion.Load())
 
 				c.config.TunnelStatus = "Connected (TCPMux)"
 
-				go c.poolMaintainer()
-				go c.channelHandler()
+				c.state.Go(c.poolMaintainer)
+				c.state.Go(c.channelHandler)
 
 				return
 			} else {
@@ -262,7 +261,7 @@ func (c *TcpMuxTransport) channelDialer() {
 
 func (c *TcpMuxTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -325,7 +324,7 @@ func (c *TcpMuxTransport) poolMaintainer() {
 				newPoolSize++
 
 				// Add a new connection to the pool
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -342,7 +341,7 @@ func (c *TcpMuxTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryString
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -350,7 +349,7 @@ func (c *TcpMuxTransport) channelHandler() {
 			default:
 				msg, err := utils.ReceiveBinaryByte(c.state.Conn())
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						c.logger.Error("failed to read from control channel. ", err)
 						go c.Restart()
 					}
@@ -359,7 +358,7 @@ func (c *TcpMuxTransport) channelHandler() {
 				msgChan <- msg
 			}
 		}
-	}()
+	})
 
 	// Main loop to listen for context cancellation or received messages
 	for {
@@ -378,7 +377,7 @@ func (c *TcpMuxTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -412,6 +411,11 @@ func (c *TcpMuxTransport) tunnelDialer() {
 
 		return
 	}
+	untrack, ok := c.state.Track(tunnelConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// Say what this connection is, so the server admits it on the nonce rather
 	// than on the address it happened to dial out from.
@@ -438,6 +442,7 @@ func (c *TcpMuxTransport) handleSession(tunnelConn net.Conn) {
 		c.logger.Errorf("failed to create mux session: %v", err)
 		return
 	}
+	defer session.Close()
 
 	for {
 		select {
@@ -458,7 +463,10 @@ func (c *TcpMuxTransport) handleSession(tunnelConn net.Conn) {
 				continue
 			}
 
-			go c.localDialer(stream, remoteAddr)
+			if !c.state.Go(func() { c.localDialer(stream, remoteAddr) }) {
+				stream.Close()
+				return
+			}
 		}
 	}
 }

--- a/internal/client/transport/udp.go
+++ b/internal/client/transport/udp.go
@@ -68,13 +68,17 @@ func NewUDPClient(parentCtx context.Context, config *UdpConfig, logger *logrus.L
 
 func (c *UdpTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = "Disconnected (UDP)"
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *UdpTransport) Stop() { c.state.Stop() }
+func (c *UdpTransport) Wait() { c.state.Wait() }
 
 func (c *UdpTransport) Restart() {
 	if !c.restartMutex.TryLock() {
@@ -89,14 +93,7 @@ func (c *UdpTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	// close control channel connection
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -124,7 +121,7 @@ func (c *UdpTransport) Restart() {
 	// set the log level again
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 
 }
 
@@ -186,13 +183,15 @@ func (c *UdpTransport) channelDialer() {
 			tunnelTCPConn.SetReadDeadline(time.Time{})
 
 			if message == c.config.Token {
-				c.state.SetConn(tunnelTCPConn)
+				if !c.state.SetConn(tunnelTCPConn) {
+					return
+				}
 				c.logger.Info("control channel established successfully")
 
 				c.config.TunnelStatus = "Connected (UDP)"
 
-				go c.poolMaintainer()
-				go c.channelHandler()
+				c.state.Go(c.poolMaintainer)
+				c.state.Go(c.channelHandler)
 
 				return
 
@@ -208,7 +207,7 @@ func (c *UdpTransport) channelDialer() {
 
 func (c *UdpTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -258,7 +257,7 @@ func (c *UdpTransport) poolMaintainer() {
 				newPoolSize++
 
 				// Add a new connection to the pool
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -275,7 +274,7 @@ func (c *UdpTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryString
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -283,7 +282,7 @@ func (c *UdpTransport) channelHandler() {
 			default:
 				msg, err := utils.ReceiveBinaryByte(c.state.Conn())
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						c.logger.Error("failed to read from control channel. ", err)
 						go c.Restart()
 					}
@@ -292,7 +291,7 @@ func (c *UdpTransport) channelHandler() {
 				msgChan <- msg
 			}
 		}
-	}()
+	})
 
 	// Main loop to listen for context cancellation or received messages
 	for {
@@ -311,7 +310,7 @@ func (c *UdpTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -373,24 +372,17 @@ func (c *UdpTransport) tunnelDialer() {
 		c.logger.Error("failed to connect to server:", err)
 		return
 	}
+	untrack, ok := c.state.Track(tunConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	c.applyBuffers(tunConn)
 
 	defer tunConn.Close()
 
-	done := make(chan struct{})
-
-	// Start handleTunnelConn in a goroutine
-	go func() {
-		c.handleTunnelConn(tunConn)
-		close(done) // Signal that handleTunnelConn is done
-	}()
-
-	// Wait for either handleTunnelConn to finish or the context to be done
-	select {
-	case <-done:
-	case <-c.state.Ctx().Done():
-	}
+	c.handleTunnelConn(tunConn)
 }
 
 func (c *UdpTransport) handleTunnelConn(tunConn *net.UDPConn) {
@@ -459,6 +451,11 @@ func (c *UdpTransport) localDialer(remoteAddr string, port int, tunConn *net.UDP
 		c.logger.Errorf("failed to dial remote UDP address: %v", err)
 		return
 	}
+	untrack, ok := c.state.Track(remoteConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	c.applyBuffers(remoteConn)
 

--- a/internal/client/transport/ws.go
+++ b/internal/client/transport/ws.go
@@ -78,14 +78,18 @@ func NewWSClient(parentCtx context.Context, config *WsConfig, logger *logrus.Log
 func (c *WsTransport) Start() {
 	// for  webui
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", c.config.Mode)
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 
 }
+func (c *WsTransport) Stop() { c.state.Stop() }
+func (c *WsTransport) Wait() { c.state.Wait() }
+
 func (c *WsTransport) Restart() {
 	if !c.restartMutex.TryLock() {
 		c.logger.Warn("client is already restarting")
@@ -99,14 +103,7 @@ func (c *WsTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	// close control channel connection
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -134,7 +131,7 @@ func (c *WsTransport) Restart() {
 	// set the log level again
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 }
 
 func (c *WsTransport) channelDialer() {
@@ -161,13 +158,15 @@ func (c *WsTransport) channelDialer() {
 				bo.Wait(c.state.Ctx())
 				continue
 			}
-			c.state.SetWSConn(tunnelWSConn)
+			if !c.state.SetWSConn(tunnelWSConn) {
+				return
+			}
 			c.logger.Info("control channel established successfully")
 
 			c.config.TunnelStatus = fmt.Sprintf("Connected (%s)", c.config.Mode)
 
-			go c.poolMaintainer()
-			go c.channelHandler()
+			c.state.Go(c.poolMaintainer)
+			c.state.Go(c.channelHandler)
 
 			return
 		}
@@ -176,7 +175,7 @@ func (c *WsTransport) channelDialer() {
 
 func (c *WsTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -226,7 +225,7 @@ func (c *WsTransport) poolMaintainer() {
 				newPoolSize++
 
 				// Add a new connection to the pool
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -243,7 +242,7 @@ func (c *WsTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryString
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -252,7 +251,7 @@ func (c *WsTransport) channelHandler() {
 			default:
 				_, msg, err := c.state.WSConn().ReadMessage()
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						c.logger.Error("failed to read from channel connection. ", err)
 						go c.Restart()
 					}
@@ -262,7 +261,7 @@ func (c *WsTransport) channelHandler() {
 				msgChan <- msg[0]
 			}
 		}
-	}()
+	})
 
 	// Main loop to listen for context cancellation or received messages
 	for {
@@ -280,7 +279,7 @@ func (c *WsTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -321,6 +320,11 @@ func (c *WsTransport) tunnelDialer() {
 
 		return
 	}
+	untrack, ok := c.state.Track(tunnelConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// Increment active connections counter
 	atomic.AddInt32(&c.poolConnections, 1)

--- a/internal/client/transport/wsmux.go
+++ b/internal/client/transport/wsmux.go
@@ -91,13 +91,17 @@ func NewWSMuxClient(parentCtx context.Context, config *WsMuxConfig, logger *logr
 
 func (c *WsMuxTransport) Start() {
 	if c.config.WebPort > 0 {
-		go c.state.Usage().Monitor()
+		usage := c.state.Usage()
+		c.state.Go(usage.Monitor)
 	}
 
 	c.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", c.config.Mode)
 
-	go c.channelDialer()
+	c.state.Go(c.channelDialer)
 }
+
+func (c *WsMuxTransport) Stop() { c.state.Stop() }
+func (c *WsMuxTransport) Wait() { c.state.Wait() }
 
 func (c *WsMuxTransport) Restart() {
 	if !c.restartMutex.TryLock() {
@@ -112,14 +116,7 @@ func (c *WsMuxTransport) Restart() {
 	level := c.logger.Level
 	c.logger.SetLevel(logrus.FatalLevel)
 
-	if c.state.Cancel() != nil {
-		c.state.Cancel()()
-	}
-
-	// close control channel connection
-	c.state.CloseConn()
-
-	time.Sleep(2 * time.Second)
+	c.state.StopAndWait()
 
 	// The whole tunnel may have been shut down while this restart was waiting —
 	// on a reload, or on the process going down. Rebuilding the run from a
@@ -151,7 +148,7 @@ func (c *WsMuxTransport) Restart() {
 	// set the log level again
 	c.logger.SetLevel(level)
 
-	go c.Start()
+	c.Start()
 }
 
 func (c *WsMuxTransport) channelDialer() {
@@ -179,13 +176,15 @@ func (c *WsMuxTransport) channelDialer() {
 				bo.Wait(c.state.Ctx())
 				continue
 			}
-			c.state.SetWSConn(tunnelWSConn)
+			if !c.state.SetWSConn(tunnelWSConn) {
+				return
+			}
 			c.logger.Info("control channel established successfully")
 
 			c.config.TunnelStatus = fmt.Sprintf("Connected (%s)", c.config.Mode)
 
-			go c.poolMaintainer()
-			go c.channelHandler()
+			c.state.Go(c.poolMaintainer)
+			c.state.Go(c.channelHandler)
 
 			return
 		}
@@ -194,7 +193,7 @@ func (c *WsMuxTransport) channelDialer() {
 
 func (c *WsMuxTransport) poolMaintainer() {
 	for i := 0; i < c.config.ConnPoolSize; i++ { //initial pool filling
-		go c.tunnelDialer()
+		c.state.Go(c.tunnelDialer)
 	}
 
 	// factors
@@ -257,7 +256,7 @@ func (c *WsMuxTransport) poolMaintainer() {
 				newPoolSize++
 
 				// Add a new connection to the pool
-				go c.tunnelDialer()
+				c.state.Go(c.tunnelDialer)
 			} else if float64(loadConnections+x) < float64(poolConnectionsAvg)*y && newPoolSize > c.config.ConnPoolSize {
 				c.logger.Debugf("decreasing pool size: %d -> %d, avg pool conn: %d, avg load conn: %d", newPoolSize, newPoolSize-1, poolConnectionsAvg, loadConnections)
 				newPoolSize--
@@ -274,7 +273,7 @@ func (c *WsMuxTransport) channelHandler() {
 	msgChan := make(chan byte, 1000)
 
 	// Goroutine to handle the blocking ReceiveBinaryString
-	go func() {
+	c.state.Go(func() {
 		for {
 			select {
 			case <-c.state.Ctx().Done():
@@ -283,7 +282,7 @@ func (c *WsMuxTransport) channelHandler() {
 			default:
 				_, msg, err := c.state.WSConn().ReadMessage()
 				if err != nil {
-					if c.state.Cancel() != nil {
+					if c.state.Ctx().Err() == nil && c.parentctx.Err() == nil {
 						c.logger.Error("failed to read from channel connection. ", err)
 						go c.Restart()
 					}
@@ -292,7 +291,7 @@ func (c *WsMuxTransport) channelHandler() {
 				msgChan <- msg[0]
 			}
 		}
-	}()
+	})
 
 	for {
 		select {
@@ -309,7 +308,7 @@ func (c *WsMuxTransport) channelHandler() {
 
 				default:
 					c.logger.Debug("channel signal received, initiating tunnel dialer")
-					go c.tunnelDialer()
+					c.state.Go(c.tunnelDialer)
 				}
 
 			case utils.SG_HB:
@@ -350,6 +349,11 @@ func (c *WsMuxTransport) tunnelDialer() {
 
 		return
 	}
+	untrack, ok := c.state.Track(tunnelWSConn)
+	if !ok {
+		return
+	}
+	defer untrack()
 
 	// Increment active connections counter
 	atomic.AddInt32(&c.poolConnections, 1)
@@ -368,6 +372,7 @@ func (c *WsMuxTransport) handleSession(tunnelConn *websocket.Conn) {
 		c.logger.Errorf("failed to create mux session: %v", err)
 		return
 	}
+	defer session.Close()
 
 	for {
 		select {
@@ -388,7 +393,10 @@ func (c *WsMuxTransport) handleSession(tunnelConn *websocket.Conn) {
 				continue
 			}
 
-			go c.localDialer(stream, remoteAddr)
+			if !c.state.Go(func() { c.localDialer(stream, remoteAddr) }) {
+				stream.Close()
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- publish each client generation as one coherent state
- prevent a delayed restart from rebuilding after the parent tunnel is shutting down
- clear generation-owned connection, pool, and metrics state on restart

## Verification
- lifecycle tests repeated 100 times
- Linux cross-build and go vet for client transports

## Why this matters
Overlapping generations can race for the same listeners, reuse stale pool identity, and keep background workers alive after reload.