### PR TITLE
fix: coordinate ACME HTTP-01 lifecycle

### DIFF
--- a/internal/server/transport/ws.go
+++ b/internal/server/transport/ws.go
@@ -341,11 +341,12 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 		// Built before the goroutine starts so a bad certificate or an
 		// unwritable ACME cache is reported here, at startup, instead of
 		// surfacing later as handshake failures on a listener that is up.
-		tlsCfg, err := network.ServerTLSConfig(s.tlsSettings(), s.logger.Warnf)
+		tlsLease, err := network.ServerTLSConfig(s.tlsSettings(), s.logger.Warnf)
 		if err != nil {
 			s.logger.Fatalf("failed to set up TLS on %s: %v", addr, err)
 		}
-		server.TLSConfig = tlsCfg
+		defer tlsLease.Close()
+		server.TLSConfig = tlsLease.Config
 
 		go func() {
 			s.logger.Infof("wss server starting, listening on %s", addr)

--- a/internal/server/transport/wsmux.go
+++ b/internal/server/transport/wsmux.go
@@ -367,11 +367,12 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 	} else {
 		// Built up front so a certificate problem fails at startup rather than
 		// per-handshake on a listener that is already accepting.
-		tlsCfg, err := network.ServerTLSConfig(s.tlsSettings(), s.logger.Warnf)
+		tlsLease, err := network.ServerTLSConfig(s.tlsSettings(), s.logger.Warnf)
 		if err != nil {
 			s.logger.Fatalf("failed to set up TLS on %s: %v", addr, err)
 		}
-		server.TLSConfig = tlsCfg
+		defer tlsLease.Close()
+		server.TLSConfig = tlsLease.Config
 
 		go func() {
 			s.logger.Infof("%s server starting, listening on %s", s.config.Mode, addr)

--- a/internal/utils/network/tlsconf.go
+++ b/internal/utils/network/tlsconf.go
@@ -1,10 +1,13 @@
 package network
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,30 +50,52 @@ type TLSSettings struct {
 // UsesACME reports whether these settings request a Let's Encrypt certificate.
 func (s TLSSettings) UsesACME() bool { return s.ACMEDomain != "" }
 
-// ServerTLSConfig builds a *tls.Config for a listener.
+// TLSLease couples a TLS configuration to the process-wide ACME responder
+// registration which serves it. Close must be called when the listener stops;
+// file-backed configurations use the same API with a no-op release.
+type TLSLease struct {
+	Config  *tls.Config
+	onClose func()
+	once    sync.Once
+}
+
+func (l *TLSLease) Close() error {
+	if l != nil {
+		l.once.Do(func() {
+			if l.onClose != nil {
+				l.onClose()
+			}
+		})
+	}
+	return nil
+}
+
+// ServerTLSConfig builds a leased TLS configuration for a listener.
 //
 // Both paths go through GetCertificate rather than a fixed certificate, so a
 // renewed certificate is picked up without restarting the tunnel. That matters
 // more than it sounds: Let's Encrypt certificates last 90 days, and a scheme
 // that needed a restart would mean a scheduled interruption every couple of
 // months on every tunnel using one.
-func ServerTLSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, error) {
-	var cfg *tls.Config
+func ServerTLSConfig(s TLSSettings, logf func(string, ...any)) (*TLSLease, error) {
+	var lease *TLSLease
 	var err error
 	if s.UsesACME() {
-		cfg, err = acmeTLSConfig(s, logf)
+		lease, err = acmeTLSConfig(s, logf)
 	} else {
+		var cfg *tls.Config
 		cfg, err = fileTLSConfig(s.CertFile, s.KeyFile)
+		lease = &TLSLease{Config: cfg}
 	}
 	if err != nil {
 		return nil, err
 	}
-	pinHTTP11ALPN(cfg)
-	return cfg, nil
+	pinHTTP11ALPN(lease.Config)
+	return lease, nil
 }
 
-// HTTPSConfig builds a *tls.Config for an ordinary HTTPS server — the web
-// panel. It offers the same two ways to get a certificate as the tunnel
+// HTTPSConfig builds a leased TLS configuration for an ordinary HTTPS server —
+// the web panel. It offers the same two ways to get a certificate as the tunnel
 // listeners, and deliberately skips the ALPN pinning they need: that exists so
 // a WebSocket upgrade can never be negotiated away to HTTP/2, and a panel has
 // no upgrade to protect.
@@ -79,11 +104,15 @@ func ServerTLSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, err
 // config whose certificate is resolved per handshake, so an ACME certificate
 // reissued at the 60-day mark of its 90-day life is served from the next
 // connection onward without restarting the panel.
-func HTTPSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, error) {
+func HTTPSConfig(s TLSSettings, logf func(string, ...any)) (*TLSLease, error) {
 	if s.UsesACME() {
 		return acmeTLSConfig(s, logf)
 	}
-	return fileTLSConfig(s.CertFile, s.KeyFile)
+	cfg, err := fileTLSConfig(s.CertFile, s.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	return &TLSLease{Config: cfg}, nil
 }
 
 // pinHTTP11ALPN forces ALPN negotiation to HTTP/1.1, dropping HTTP/2 while
@@ -168,7 +197,7 @@ func (r *certReloader) get(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 
 // --- Let's Encrypt ----------------------------------------------------------
 
-func acmeTLSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, error) {
+func acmeTLSConfig(s TLSSettings, logf func(string, ...any)) (*TLSLease, error) {
 	if s.ACMECacheDir == "" {
 		return nil, fmt.Errorf("acme cache directory is not set")
 	}
@@ -176,11 +205,9 @@ func acmeTLSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, error
 		return nil, fmt.Errorf("acme cache directory: %w", err)
 	}
 
-	m := &autocert.Manager{
-		Prompt:     autocert.AcceptTOS,
-		Cache:      autocert.DirCache(s.ACMECacheDir),
-		HostPolicy: autocert.HostWhitelist(s.ACMEDomain),
-		Email:      s.ACMEEmail,
+	m, release, err := processACME.acquire(s, logf)
+	if err != nil {
+		return nil, err
 	}
 
 	cfg := m.TLSConfig()
@@ -192,13 +219,7 @@ func acmeTLSConfig(s TLSSettings, logf func(string, ...any)) (*tls.Config, error
 		cfg.NextProtos = append(cfg.NextProtos, acme.ALPNProto)
 	}
 
-	// A tunnel that is not on 443 cannot be validated that way, so an HTTP-01
-	// responder is started on port 80 as well. It is best effort: if the port
-	// is taken, TLS-ALPN may still work, and saying so is more useful than
-	// refusing to start.
-	go serveACMEHTTP(m, logf)
-
-	return cfg, nil
+	return &TLSLease{Config: cfg, onClose: release}, nil
 }
 
 func hasProto(list []string, want string) bool {
@@ -210,16 +231,231 @@ func hasProto(list []string, want string) bool {
 	return false
 }
 
-// serveACMEHTTP runs the HTTP-01 responder on port 80.
-func serveACMEHTTP(m *autocert.Manager, logf func(string, ...any)) {
-	srv := &http.Server{
-		Addr:         ":80",
-		Handler:      m.HTTPHandler(nil),
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+type acmeEntry struct {
+	manager  *autocert.Manager
+	handler  http.Handler
+	cacheDir string
+	email    string
+	refs     int
+}
+
+// acmeRegistry owns the single HTTP-01 listener a process is allowed to have.
+// Its handler dispatches challenges to the manager registered for the request
+// host, so independent tunnels and the web panel can safely share port 80.
+type acmeRegistry struct {
+	mu          sync.Mutex
+	cond        *sync.Cond
+	addr        string
+	entries     map[string]*acmeEntry
+	total       int
+	server      *http.Server
+	listener    net.Listener
+	done        chan struct{}
+	stopping    bool
+	attempted   bool
+	httpHandler http.Handler
+	retryStop   chan struct{}
+	retryDone   chan struct{}
+	retryEvery  time.Duration
+}
+
+func newACMERegistry(addr string) *acmeRegistry {
+	r := &acmeRegistry{addr: addr, entries: make(map[string]*acmeEntry), retryEvery: time.Second}
+	r.cond = sync.NewCond(&r.mu)
+	return r
+}
+
+var processACME = newACMERegistry(":80")
+
+func (r *acmeRegistry) acquire(s TLSSettings, logf func(string, ...any)) (*autocert.Manager, func(), error) {
+	domain := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(s.ACMEDomain), "."))
+	if domain == "" {
+		return nil, nil, fmt.Errorf("acme domain is not set")
 	}
-	if err := srv.ListenAndServe(); err != nil {
-		logf("ACME HTTP-01 responder could not use port 80 (%v); "+
-			"validation will rely on TLS-ALPN, which needs the tunnel to be on port 443", err)
+
+	r.mu.Lock()
+	for r.stopping {
+		r.cond.Wait()
+	}
+	if existing := r.entries[domain]; existing != nil {
+		if existing.cacheDir != s.ACMECacheDir || existing.email != s.ACMEEmail {
+			r.mu.Unlock()
+			return nil, nil, fmt.Errorf("acme domain %q is already registered with different account settings", domain)
+		}
+		existing.refs++
+		r.total++
+		manager := existing.manager
+		r.mu.Unlock()
+		return manager, r.releaseFunc(domain), nil
+	}
+
+	manager := &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		Cache:      autocert.DirCache(s.ACMECacheDir),
+		HostPolicy: autocert.HostWhitelist(domain),
+		Email:      s.ACMEEmail,
+	}
+	// Calling HTTPHandler opts this manager into http-01 before certificate
+	// issuance starts. Deferring this until the first challenge request would be
+	// too late: autocert would already have selected tls-alpn-01 only.
+	handler := manager.HTTPHandler(nil)
+	r.entries[domain] = &acmeEntry{manager: manager, handler: handler, cacheDir: s.ACMECacheDir, email: s.ACMEEmail, refs: 1}
+	r.total++
+	if r.httpHandler == nil {
+		shared := &autocert.Manager{
+			Cache: autocert.DirCache(s.ACMECacheDir),
+			HostPolicy: func(context.Context, string) error {
+				// Challenge tokens are unguessable and public by design. Allowing
+				// any Host here lets the process which owns port 80 serve a token
+				// written to the shared cache by another Backpack process.
+				return nil
+			},
+		}
+		r.httpHandler = shared.HTTPHandler(nil)
+	}
+	if r.server == nil && !r.attempted {
+		r.startLocked(logf)
+	}
+	r.mu.Unlock()
+	return manager, r.releaseFunc(domain), nil
+}
+
+func (r *acmeRegistry) startLocked(logf func(string, ...any)) {
+	r.attempted = true
+	if err := r.listenLocked(logf); err == nil {
+		return
+	} else {
+		logACME(logf, "ACME HTTP-01 responder could not use %s (%v); another Backpack process may own it, so this process will keep retrying", r.addr, err)
+	}
+	r.retryStop, r.retryDone = make(chan struct{}), make(chan struct{})
+	stop, done := r.retryStop, r.retryDone
+	go r.retryListen(stop, done, logf)
+}
+
+func (r *acmeRegistry) listenLocked(logf func(string, ...any)) error {
+	listener, err := net.Listen("tcp", r.addr)
+	if err != nil {
+		return err
+	}
+	srv := &http.Server{
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+	r.server, r.listener, r.done = srv, listener, make(chan struct{})
+	done := r.done
+	go func() {
+		defer close(done)
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			logACME(logf, "ACME HTTP-01 responder stopped: %v", err)
+		}
+	}()
+	return nil
+}
+
+func (r *acmeRegistry) retryListen(stop <-chan struct{}, done chan<- struct{}, logf func(string, ...any)) {
+	defer close(done)
+	ticker := time.NewTicker(r.retryEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			r.mu.Lock()
+			if r.total == 0 || r.server != nil || r.retryStop != stop {
+				r.mu.Unlock()
+				return
+			}
+			if err := r.listenLocked(logf); err == nil {
+				r.retryStop, r.retryDone = nil, nil
+				r.mu.Unlock()
+				logACME(logf, "ACME HTTP-01 responder acquired %s", r.addr)
+				return
+			}
+			r.mu.Unlock()
+		}
+	}
+}
+
+func (r *acmeRegistry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	host := req.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	r.mu.Lock()
+	entry := r.entries[host]
+	handler := r.httpHandler
+	r.mu.Unlock()
+	if entry != nil {
+		entry.handler.ServeHTTP(w, req)
+		return
+	}
+	if handler == nil || !strings.HasPrefix(req.URL.Path, "/.well-known/acme-challenge/") {
+		http.NotFound(w, req)
+		return
+	}
+	// DirCache stores http-01 tokens, so this fallback also serves challenges
+	// created by another Backpack process using the same persistent cache.
+	handler.ServeHTTP(w, req)
+}
+
+func (r *acmeRegistry) releaseFunc(domain string) func() {
+	var once sync.Once
+	return func() { once.Do(func() { r.release(domain) }) }
+}
+
+func (r *acmeRegistry) release(domain string) {
+	r.mu.Lock()
+	entry := r.entries[domain]
+	if entry == nil {
+		r.mu.Unlock()
+		return
+	}
+	entry.refs--
+	r.total--
+	if entry.refs == 0 {
+		delete(r.entries, domain)
+	}
+	if r.total > 0 {
+		r.mu.Unlock()
+		return
+	}
+
+	srv, done := r.server, r.done
+	retryStop, retryDone := r.retryStop, r.retryDone
+	r.server, r.listener, r.done = nil, nil, nil
+	r.retryStop, r.retryDone = nil, nil
+	r.attempted = false
+	r.httpHandler = nil
+	if srv != nil || retryStop != nil {
+		r.stopping = true
+	}
+	r.mu.Unlock()
+
+	if retryStop != nil {
+		close(retryStop)
+		<-retryDone
+	}
+	if srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = srv.Shutdown(ctx)
+		cancel()
+		<-done
+	}
+	if srv != nil || retryStop != nil {
+		r.mu.Lock()
+		r.stopping = false
+		r.cond.Broadcast()
+		r.mu.Unlock()
+	}
+}
+
+func logACME(logf func(string, ...any), format string, args ...any) {
+	if logf != nil {
+		logf(format, args...)
 	}
 }

--- a/internal/utils/network/tlsconf_acme_test.go
+++ b/internal/utils/network/tlsconf_acme_test.go
@@ -1,0 +1,209 @@
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+func TestACMERegistrySharesOneHTTPResponder(t *testing.T) {
+	r := newACMERegistry("127.0.0.1:0")
+	first := TLSSettings{ACMEDomain: "one.example", ACMEEmail: "ops@example.com", ACMECacheDir: t.TempDir()}
+	second := TLSSettings{ACMEDomain: "two.example", ACMEEmail: "ops@example.com", ACMECacheDir: t.TempDir()}
+
+	_, releaseFirst, err := r.acquire(first, t.Logf)
+	if err != nil {
+		t.Fatalf("register first domain: %v", err)
+	}
+	r.mu.Lock()
+	server := r.server
+	addr := r.listener.Addr().String()
+	r.mu.Unlock()
+
+	_, releaseSecond, err := r.acquire(second, t.Logf)
+	if err != nil {
+		t.Fatalf("register second domain: %v", err)
+	}
+	r.mu.Lock()
+	if r.server != server {
+		t.Fatal("second domain started another HTTP-01 server")
+	}
+	if got := len(r.entries); got != 2 {
+		t.Fatalf("registered domains = %d, want 2", got)
+	}
+	r.mu.Unlock()
+
+	unknown := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://unknown.example/.well-known/acme-challenge/test", nil)
+	r.ServeHTTP(unknown, req)
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown ACME host status = %d, want 404", unknown.Code)
+	}
+
+	releaseFirst()
+	r.mu.Lock()
+	if r.server == nil || r.total != 1 {
+		t.Fatal("releasing one domain stopped the shared responder")
+	}
+	r.mu.Unlock()
+
+	releaseSecond()
+	r.mu.Lock()
+	if r.server != nil || r.total != 0 || len(r.entries) != 0 {
+		t.Fatal("last release did not clear the ACME registry")
+	}
+	r.mu.Unlock()
+
+	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("HTTP-01 listener remained open after its last lease closed")
+	}
+}
+
+func TestACMERegistrySharesManagerForSameDomain(t *testing.T) {
+	r := newACMERegistry("127.0.0.1:0")
+	settings := TLSSettings{ACMEDomain: "Shared.Example.", ACMEEmail: "ops@example.com", ACMECacheDir: t.TempDir()}
+
+	first, releaseFirst, err := r.acquire(settings, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, releaseSecond, err := r.acquire(settings, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("same domain and account settings created two autocert managers")
+	}
+
+	releaseFirst()
+	releaseFirst() // release functions are intentionally idempotent
+	r.mu.Lock()
+	if r.total != 1 {
+		t.Fatalf("idempotent release left %d leases, want 1", r.total)
+	}
+	r.mu.Unlock()
+	releaseSecond()
+}
+
+func TestACMERegistryRejectsConflictingAccountSettings(t *testing.T) {
+	r := newACMERegistry("127.0.0.1:0")
+	settings := TLSSettings{ACMEDomain: "conflict.example", ACMEEmail: "one@example.com", ACMECacheDir: t.TempDir()}
+	_, release, err := r.acquire(settings, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	conflict := settings
+	conflict.ACMEEmail = "two@example.com"
+	if _, _, err := r.acquire(conflict, nil); err == nil {
+		t.Fatal("same domain was accepted with conflicting ACME account settings")
+	}
+}
+
+func TestTLSLeaseCloseIsIdempotent(t *testing.T) {
+	var calls atomic.Int32
+	lease := &TLSLease{onClose: func() { calls.Add(1) }}
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = lease.Close()
+		}()
+	}
+	wg.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("lease release called %d times, want once", got)
+	}
+}
+
+func TestACMEResponderServesSharedCacheAndHandsOffAcrossProcesses(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	probe.Close()
+
+	cacheDir := t.TempDir()
+	owner := newACMERegistry(addr)
+	standby := newACMERegistry(addr)
+	standby.retryEvery = 10 * time.Millisecond
+	one := TLSSettings{ACMEDomain: "one.example", ACMECacheDir: cacheDir}
+	two := TLSSettings{ACMEDomain: "two.example", ACMECacheDir: cacheDir}
+
+	_, releaseOwner, err := owner.acquire(one, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, releaseStandby, err := standby.acquire(two, t.Logf)
+	if err != nil {
+		releaseOwner()
+		t.Fatal(err)
+	}
+	defer releaseStandby()
+
+	standby.mu.Lock()
+	if standby.server != nil || standby.retryStop == nil {
+		standby.mu.Unlock()
+		releaseOwner()
+		t.Fatal("second process neither waited for nor unexpectedly acquired the occupied port")
+	}
+	standby.mu.Unlock()
+
+	const token = "cross-process-token"
+	const response = "cross-process-token.key-authorization"
+	cache := autocert.DirCache(cacheDir)
+	if err := cache.Put(context.Background(), token+"+http-01", []byte(response)); err != nil {
+		releaseOwner()
+		t.Fatalf("write shared challenge token: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/.well-known/acme-challenge/"+token, nil)
+	if err != nil {
+		releaseOwner()
+		t.Fatal(err)
+	}
+	req.Host = "two.example"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		releaseOwner()
+		t.Fatalf("request challenge through the owner process: %v", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		releaseOwner()
+		t.Fatal(readErr)
+	}
+	if string(body) != response {
+		releaseOwner()
+		t.Fatalf("shared-cache challenge response = %q, want %q", body, response)
+	}
+
+	releaseOwner()
+	deadline := time.Now().Add(time.Second)
+	for {
+		standby.mu.Lock()
+		acquired := standby.server != nil
+		standby.mu.Unlock()
+		if acquired {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("standby process did not acquire port 80 after the owner released it")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -254,13 +254,14 @@ func Serve() error {
 		}
 		settings.CertFile, settings.KeyFile = certFile, keyFile
 	}
-	tlsCfg, err := network.HTTPSConfig(settings, func(format string, a ...any) {
+	tlsLease, err := network.HTTPSConfig(settings, func(format string, a ...any) {
 		log.Printf(format, a...)
 	})
 	if err != nil {
 		return fmt.Errorf("web panel TLS: %w", err)
 	}
-	httpServer.TLSConfig = tlsCfg
+	defer tlsLease.Close()
+	httpServer.TLSConfig = tlsLease.Config
 	return httpServer.ListenAndServeTLS("", "")
 }
 


### PR DESCRIPTION
## Summary
- coordinate HTTP-01 listeners across concurrent TLS configurations in one process
- share the ACME cache responder safely across processes using the configured challenge port
- release challenge listeners when their owning context ends

## Verification
- ACME lifecycle tests repeated 25 times
- Linux cross-build and go vet for network, client, and server packages

## Why this matters
Concurrent tunnels could race on port 80, leak challenge servers across reloads, or fail renewal despite sharing the same certificate cache.