### PR TITLE
fix: harden WebSocket protocol boundaries

### DIFF
--- a/internal/client/transport/ws.go
+++ b/internal/client/transport/ws.go
@@ -161,6 +161,7 @@ func (c *WsTransport) channelDialer() {
 				bo.Wait(c.state.Ctx())
 				continue
 			}
+			tunnelWSConn.SetReadLimit(1)
 			c.state.SetWSConn(tunnelWSConn)
 			c.logger.Info("control channel established successfully")
 
@@ -250,7 +251,7 @@ func (c *WsTransport) channelHandler() {
 				return
 
 			default:
-				_, msg, err := c.state.WSConn().ReadMessage()
+				messageType, msg, err := c.state.WSConn().ReadMessage()
 				if err != nil {
 					if c.state.Cancel() != nil {
 						c.logger.Error("failed to read from channel connection. ", err)
@@ -258,8 +259,18 @@ func (c *WsTransport) channelHandler() {
 					}
 					return
 				}
-
-				msgChan <- msg[0]
+				signal, err := utils.DecodeWebSocketSignal(messageType, msg)
+				if err != nil {
+					c.logger.Warnf("invalid WebSocket control frame: %v", err)
+					c.state.WSConn().Close()
+					go c.Restart()
+					return
+				}
+				select {
+				case msgChan <- signal:
+				case <-c.state.Ctx().Done():
+					return
+				}
 			}
 		}
 	}()
@@ -321,6 +332,7 @@ func (c *WsTransport) tunnelDialer() {
 
 		return
 	}
+	tunnelConn.SetReadLimit(64 << 10)
 
 	// Increment active connections counter
 	atomic.AddInt32(&c.poolConnections, 1)

--- a/internal/client/transport/wsmux.go
+++ b/internal/client/transport/wsmux.go
@@ -179,6 +179,7 @@ func (c *WsMuxTransport) channelDialer() {
 				bo.Wait(c.state.Ctx())
 				continue
 			}
+			tunnelWSConn.SetReadLimit(1)
 			c.state.SetWSConn(tunnelWSConn)
 			c.logger.Info("control channel established successfully")
 
@@ -281,7 +282,7 @@ func (c *WsMuxTransport) channelHandler() {
 				return
 
 			default:
-				_, msg, err := c.state.WSConn().ReadMessage()
+				messageType, msg, err := c.state.WSConn().ReadMessage()
 				if err != nil {
 					if c.state.Cancel() != nil {
 						c.logger.Error("failed to read from channel connection. ", err)
@@ -289,7 +290,18 @@ func (c *WsMuxTransport) channelHandler() {
 					}
 					return
 				}
-				msgChan <- msg[0]
+				signal, err := utils.DecodeWebSocketSignal(messageType, msg)
+				if err != nil {
+					c.logger.Warnf("invalid WebSocket control frame: %v", err)
+					c.state.WSConn().Close()
+					go c.Restart()
+					return
+				}
+				select {
+				case msgChan <- signal:
+				case <-c.state.Ctx().Done():
+					return
+				}
 			}
 		}
 	}()

--- a/internal/server/transport/ws.go
+++ b/internal/server/transport/ws.go
@@ -187,7 +187,7 @@ func (s *WsTransport) channelHandler(g *wsGen) {
 				return
 
 			default:
-				_, msg, err := s.controlChannel.Get().ReadMessage()
+				messageType, msg, err := s.controlChannel.Get().ReadMessage()
 				// Exit if there's an error
 				if err != nil {
 					if s.cancel != nil {
@@ -196,7 +196,18 @@ func (s *WsTransport) channelHandler(g *wsGen) {
 					}
 					return
 				}
-				messageChan <- msg[0]
+				signal, err := utils.DecodeWebSocketSignal(messageType, msg)
+				if err != nil {
+					s.logger.Warnf("invalid WebSocket control frame: %v", err)
+					s.controlChannel.Close()
+					go s.Restart()
+					return
+				}
+				select {
+				case messageChan <- signal:
+				case <-g.ctx.Done():
+					return
+				}
 			}
 		}
 	}()
@@ -252,7 +263,7 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:   16 * 1024,
 		WriteBufferSize:  16 * 1024,
-		HandshakeTimeout: 45 * time.Second,
+		HandshakeTimeout: 10 * time.Second,
 		CheckOrigin: func(r *http.Request) bool {
 			return true
 		},
@@ -260,8 +271,7 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 
 	// Create an HTTP server
 	server := &http.Server{
-		Addr:        addr,
-		IdleTimeout: -1,
+		Addr: addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s.logger.Tracef("received http request from %s", r.RemoteAddr)
 
@@ -282,6 +292,7 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 			}
 
 			if r.URL.Path == "/channel" {
+				conn.SetReadLimit(1)
 				if s.controlChannel.IsSet() {
 					s.logger.Warn("new control channel requested.")
 					s.controlChannel.Close()
@@ -310,6 +321,10 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 				s.config.TunnelStatus = fmt.Sprintf("Connected (%s)", s.config.Mode)
 
 			} else if strings.HasPrefix(r.URL.Path, "/tunnel") {
+				// Relay writes are 16 KiB; leave headroom for compatibility while
+				// preventing one authenticated peer from forcing an unbounded
+				// ReadMessage allocation.
+				conn.SetReadLimit(64 << 10)
 				wsConn := TunnelChannel{
 					conn: conn,
 					ping: make(chan struct{}),
@@ -326,6 +341,7 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 			}
 		}),
 	}
+	hardenWebSocketHTTPServer(server)
 
 	if s.config.Mode == config.WS {
 		go func() {

--- a/internal/server/transport/wsmux.go
+++ b/internal/server/transport/wsmux.go
@@ -214,7 +214,7 @@ func (s *WsMuxTransport) channelHandler(g *wsMuxGen) {
 				return
 
 			default:
-				_, msg, err := s.controlChannel.Get().ReadMessage()
+				messageType, msg, err := s.controlChannel.Get().ReadMessage()
 				// Exit if there's an error
 				if err != nil {
 					if s.cancel != nil {
@@ -223,7 +223,18 @@ func (s *WsMuxTransport) channelHandler(g *wsMuxGen) {
 					}
 					return
 				}
-				messageChan <- msg[0]
+				signal, err := utils.DecodeWebSocketSignal(messageType, msg)
+				if err != nil {
+					s.logger.Warnf("invalid WebSocket control frame: %v", err)
+					s.controlChannel.Close()
+					go s.Restart()
+					return
+				}
+				select {
+				case messageChan <- signal:
+				case <-g.ctx.Done():
+					return
+				}
 			}
 		}
 	}()
@@ -279,7 +290,7 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:   16 * 1024,
 		WriteBufferSize:  16 * 1024,
-		HandshakeTimeout: 45 * time.Second,
+		HandshakeTimeout: 10 * time.Second,
 		CheckOrigin: func(r *http.Request) bool {
 			return true
 		},
@@ -287,8 +298,7 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 
 	// Create an HTTP server
 	server := &http.Server{
-		Addr:        addr,
-		IdleTimeout: -1,
+		Addr: addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s.logger.Tracef("received http request from %s", r.RemoteAddr)
 
@@ -309,6 +319,7 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 			}
 
 			if r.URL.Path == "/channel" {
+				conn.SetReadLimit(1)
 				if s.controlChannel.IsSet() {
 					s.logger.Warn("new control channel requested.")
 					s.controlChannel.Close()
@@ -353,6 +364,7 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 			}
 		}),
 	}
+	hardenWebSocketHTTPServer(server)
 
 	if s.config.Mode == config.WSMUX {
 		go func() {

--- a/internal/server/transport/wsserver.go
+++ b/internal/server/transport/wsserver.go
@@ -1,0 +1,13 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+)
+
+func hardenWebSocketHTTPServer(srv *http.Server) {
+	srv.ReadHeaderTimeout = 10 * time.Second
+	srv.WriteTimeout = 15 * time.Second
+	srv.IdleTimeout = 60 * time.Second
+	srv.MaxHeaderBytes = 16 << 10
+}

--- a/internal/server/transport/wsserver_test.go
+++ b/internal/server/transport/wsserver_test.go
@@ -1,0 +1,28 @@
+package transport
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestWebSocketHTTPServerHasBoundaryTimeouts(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	srv := &http.Server{Addr: "127.0.0.1:0", Handler: handler}
+	hardenWebSocketHTTPServer(srv)
+	if srv.Handler == nil || srv.Addr != "127.0.0.1:0" {
+		t.Fatal("server lost its handler or address")
+	}
+	if srv.ReadHeaderTimeout != 10*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want 10s", srv.ReadHeaderTimeout)
+	}
+	if srv.WriteTimeout != 15*time.Second {
+		t.Fatalf("WriteTimeout = %v, want 15s", srv.WriteTimeout)
+	}
+	if srv.IdleTimeout != 60*time.Second {
+		t.Fatalf("IdleTimeout = %v, want 60s", srv.IdleTimeout)
+	}
+	if srv.MaxHeaderBytes != 16<<10 {
+		t.Fatalf("MaxHeaderBytes = %d, want %d", srv.MaxHeaderBytes, 16<<10)
+	}
+}

--- a/internal/utils/wscontrol.go
+++ b/internal/utils/wscontrol.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+// DecodeWebSocketSignal validates the one-byte binary frames used by the
+// WebSocket control channel. Treating arbitrary frames as msg[0] let an empty
+// frame panic the process and silently accepted trailing protocol data.
+func DecodeWebSocketSignal(messageType int, payload []byte) (byte, error) {
+	if messageType != websocket.BinaryMessage {
+		return 0, fmt.Errorf("control frame type %d is not binary", messageType)
+	}
+	if len(payload) != 1 {
+		return 0, fmt.Errorf("control frame has %d bytes, want exactly 1", len(payload))
+	}
+	return payload[0], nil
+}

--- a/internal/utils/wscontrol_test.go
+++ b/internal/utils/wscontrol_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestDecodeWebSocketSignal(t *testing.T) {
+	tests := []struct {
+		name    string
+		typ     int
+		payload []byte
+		want    byte
+		wantErr bool
+	}{
+		{name: "binary byte", typ: websocket.BinaryMessage, payload: []byte{SG_HB}, want: SG_HB},
+		{name: "empty", typ: websocket.BinaryMessage, payload: nil, wantErr: true},
+		{name: "trailing data", typ: websocket.BinaryMessage, payload: []byte{SG_HB, SG_Closed}, wantErr: true},
+		{name: "text", typ: websocket.TextMessage, payload: []byte{SG_HB}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodeWebSocketSignal(tc.typ, tc.payload)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Fatalf("signal = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- validate binary control signals before indexing their payload
- reject empty, oversized, and unexpected WebSocket messages
- add read limits and bounded HTTP handshake/header timeouts

## Verification
- native protocol/helper tests
- Linux client/server transport cross-build and go vet

## Why this matters
Malformed frames could panic handlers or retain excessive memory, while unbounded handshakes exposed the listeners to slow-client resource exhaustion.