### PR TITLE
fix: harden web panel authentication

### DIFF
--- a/internal/webui/handlers_security.go
+++ b/internal/webui/handlers_security.go
@@ -2,7 +2,6 @@ package webui
 
 import (
 	"crypto/subtle"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -11,64 +10,6 @@ import (
 	"github.com/backpack/backpack/internal/manage"
 	"github.com/backpack/backpack/internal/telegram"
 )
-
-// --- login rate limiting -----------------------------------------------------
-
-// A wrong password already costs a one-second delay; this adds a ceiling: five
-// consecutive failures from one address block that address for ten minutes.
-// The panel sits on a public port on a server whose address gets scanned, and
-// an eight-digit password should not be brute-forceable just because nobody
-// was watching the log.
-const (
-	loginMaxFails    = 5
-	loginBlockPeriod = 10 * time.Minute
-)
-
-type loginLimiter struct {
-	mu    sync.Mutex
-	fails map[string]int
-	until map[string]time.Time
-}
-
-var limiter = &loginLimiter{fails: map[string]int{}, until: map[string]time.Time{}}
-
-// blocked reports whether ip is currently locked out, and for how much longer.
-func (l *loginLimiter) blocked(ip string) (bool, time.Duration) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if t, ok := l.until[ip]; ok {
-		if left := time.Until(t); left > 0 {
-			return true, left
-		}
-		delete(l.until, ip)
-		delete(l.fails, ip)
-	}
-	return false, 0
-}
-
-func (l *loginLimiter) fail(ip string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.fails[ip]++
-	if l.fails[ip] >= loginMaxFails {
-		l.until[ip] = time.Now().Add(loginBlockPeriod)
-	}
-}
-
-func (l *loginLimiter) reset(ip string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	delete(l.fails, ip)
-	delete(l.until, ip)
-}
-
-func clientIP(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
-}
 
 // --- two-factor login --------------------------------------------------------
 
@@ -156,11 +97,7 @@ func (s *server) startTwoFA(w http.ResponseWriter) bool {
 		twoFA.cancel(token)
 		return false
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name: pendingCookie, Value: token, Path: "/",
-		HttpOnly: true, SameSite: http.SameSiteLaxMode,
-		MaxAge: int(twoFACodeTTL / time.Second),
-	})
+	s.setAuthCookie(w, pendingCookie, token, twoFACodeTTL)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(codePage("")))
 	return true
@@ -176,20 +113,19 @@ func (s *server) handleLogin2FA(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 		return
 	}
-	r.ParseForm()
+	if !parseAuthForm(w, r) {
+		return
+	}
 	ok, dead := twoFA.verify(c.Value, strings.TrimSpace(r.FormValue("code")))
 	switch {
 	case ok:
-		http.SetCookie(w, &http.Cookie{Name: pendingCookie, Value: "", Path: "/", MaxAge: -1})
+		s.clearAuthCookie(w, pendingCookie)
 		tok := s.sessions.create(clientIP(r))
 		notifyLogin(r)
-		http.SetCookie(w, &http.Cookie{
-			Name: sessionCookie, Value: tok, Path: "/",
-			HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: 12 * 3600,
-		})
+		s.setAuthCookie(w, sessionCookie, tok, 12*time.Hour)
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	case dead:
-		http.SetCookie(w, &http.Cookie{Name: pendingCookie, Value: "", Path: "/", MaxAge: -1})
+		s.clearAuthCookie(w, pendingCookie)
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 	default:
 		time.Sleep(1 * time.Second)

--- a/internal/webui/httpsecurity.go
+++ b/internal/webui/httpsecurity.go
@@ -1,0 +1,101 @@
+package webui
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const maxAuthForm = 8 << 10
+
+func parseAuthForm(w http.ResponseWriter, r *http.Request) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAuthForm)
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid or oversized form", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func passwordMatches(given, want string) bool {
+	gotHash := sha256.Sum256([]byte(given))
+	wantHash := sha256.Sum256([]byte(want))
+	return subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) == 1
+}
+
+func newAuthCookie(name, value string, ttl time.Duration, secure bool) *http.Cookie {
+	return &http.Cookie{
+		Name: name, Value: value, Path: "/",
+		HttpOnly: true, Secure: secure,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   int(ttl / time.Second), Expires: time.Now().Add(ttl),
+	}
+}
+
+func expiredAuthCookie(name string, secure bool) *http.Cookie {
+	return &http.Cookie{
+		Name: name, Value: "", Path: "/",
+		HttpOnly: true, Secure: secure,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1, Expires: time.Unix(1, 0),
+	}
+}
+
+func securePanelHTTP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setPanelSecurityHeaders(w)
+		if isUnsafeMethod(r.Method) && !sameOriginRequest(r) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func setPanelSecurityHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.github.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; worker-src 'self'; manifest-src 'self'")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+	w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+	w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+}
+
+func isUnsafeMethod(method string) bool {
+	return method != http.MethodGet && method != http.MethodHead && method != http.MethodOptions
+}
+
+func sameOriginRequest(r *http.Request) bool {
+	if strings.EqualFold(r.Header.Get("Sec-Fetch-Site"), "cross-site") {
+		return false
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true // non-browser clients; SameSite protects browser cookies
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.User != nil || u.Host == "" || !strings.EqualFold(u.Host, r.Host) {
+		return false
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return strings.EqualFold(u.Scheme, scheme)
+}
+
+func newPanelHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    32 << 10,
+	}
+}

--- a/internal/webui/httpsecurity_test.go
+++ b/internal/webui/httpsecurity_test.go
@@ -1,0 +1,97 @@
+package webui
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAuthCookiesUseStrictProductionAttributes(t *testing.T) {
+	w := httptest.NewRecorder()
+	http.SetCookie(w, newAuthCookie("session", "token", time.Hour, true))
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %d, want 1", len(cookies))
+	}
+	c := cookies[0]
+	if !c.Secure || !c.HttpOnly || c.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("insecure session cookie: Secure=%v HttpOnly=%v SameSite=%v", c.Secure, c.HttpOnly, c.SameSite)
+	}
+	if c.MaxAge <= 0 || c.Expires.Before(time.Now()) {
+		t.Fatal("session cookie has no usable expiry")
+	}
+
+	w = httptest.NewRecorder()
+	http.SetCookie(w, expiredAuthCookie("session", true))
+	c = w.Result().Cookies()[0]
+	if c.MaxAge != -1 || !c.Secure || !c.HttpOnly || c.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("cookie deletion did not preserve security attributes: %+v", c)
+	}
+}
+
+func TestSecureHTTPHeadersAndOriginChecks(t *testing.T) {
+	called := 0
+	h := securePanelHTTP(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "http://panel.example/", nil))
+	if w.Code != http.StatusNoContent || called != 1 {
+		t.Fatalf("same-origin GET status=%d called=%d", w.Code, called)
+	}
+	for _, name := range []string{"Content-Security-Policy", "X-Content-Type-Options", "X-Frame-Options", "Referrer-Policy", "Permissions-Policy"} {
+		if w.Header().Get(name) == "" {
+			t.Errorf("missing security header %s", name)
+		}
+	}
+
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://panel.example/api/password", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden || called != 1 {
+		t.Fatalf("cross-origin POST status=%d called=%d", w.Code, called)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "https://panel.example/api/password", nil)
+	req.TLS = &tls.ConnectionState{}
+	req.Header.Set("Origin", "https://panel.example")
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent || called != 2 {
+		t.Fatalf("same-origin HTTPS POST status=%d called=%d", w.Code, called)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "http://panel.example/api/password", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden || called != 2 {
+		t.Fatalf("cross-site fetch metadata status=%d called=%d", w.Code, called)
+	}
+}
+
+func TestAuthFormSizeAndPasswordComparison(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader("password="+strings.Repeat("x", maxAuthForm)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if parseAuthForm(w, req) || w.Code != http.StatusBadRequest {
+		t.Fatalf("oversized login form accepted with status %d", w.Code)
+	}
+	if !passwordMatches("correct horse", "correct horse") || passwordMatches("wrong", "correct horse") {
+		t.Fatal("fixed-length password comparison returned the wrong result")
+	}
+}
+
+func TestPanelHTTPServerTimeouts(t *testing.T) {
+	srv := newPanelHTTPServer("127.0.0.1:0", http.NotFoundHandler())
+	if srv.ReadHeaderTimeout != 10*time.Second || srv.ReadTimeout != 15*time.Second ||
+		srv.WriteTimeout != 30*time.Second || srv.IdleTimeout != 60*time.Second || srv.MaxHeaderBytes != 32<<10 {
+		t.Fatalf("unexpected panel HTTP limits: %+v", srv)
+	}
+}

--- a/internal/webui/login_limiter.go
+++ b/internal/webui/login_limiter.go
@@ -1,0 +1,96 @@
+package webui
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	loginMaxFails    = 5
+	loginBlockPeriod = 10 * time.Minute
+	loginMaxTracked  = 4096
+)
+
+type loginLimiter struct {
+	mu    sync.Mutex
+	fails map[string]int
+	until map[string]time.Time
+	seen  map[string]time.Time
+}
+
+var limiter = newLoginLimiter()
+
+func newLoginLimiter() *loginLimiter {
+	return &loginLimiter{fails: map[string]int{}, until: map[string]time.Time{}, seen: map[string]time.Time{}}
+}
+
+func (l *loginLimiter) initLocked() {
+	if l.fails == nil {
+		l.fails = map[string]int{}
+	}
+	if l.until == nil {
+		l.until = map[string]time.Time{}
+	}
+	if l.seen == nil {
+		l.seen = map[string]time.Time{}
+	}
+}
+
+func (l *loginLimiter) blocked(ip string) (bool, time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.initLocked()
+	if blockedUntil, ok := l.until[ip]; ok {
+		if left := time.Until(blockedUntil); left > 0 {
+			return true, left
+		}
+		delete(l.until, ip)
+		delete(l.fails, ip)
+		delete(l.seen, ip)
+	}
+	return false, 0
+}
+
+func (l *loginLimiter) fail(ip string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.initLocked()
+	if _, exists := l.fails[ip]; !exists && len(l.fails) >= loginMaxTracked {
+		var oldestIP string
+		var oldest time.Time
+		for candidate := range l.fails {
+			lastSeen := l.seen[candidate]
+			if oldestIP == "" || lastSeen.Before(oldest) {
+				oldestIP, oldest = candidate, lastSeen
+			}
+		}
+		delete(l.fails, oldestIP)
+		delete(l.until, oldestIP)
+		delete(l.seen, oldestIP)
+	}
+	now := time.Now()
+	l.fails[ip]++
+	l.seen[ip] = now
+	if l.fails[ip] >= loginMaxFails {
+		l.until[ip] = now.Add(loginBlockPeriod)
+	}
+}
+
+func (l *loginLimiter) reset(ip string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.initLocked()
+	delete(l.fails, ip)
+	delete(l.until, ip)
+	delete(l.seen, ip)
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/webui/login_limiter_test.go
+++ b/internal/webui/login_limiter_test.go
@@ -1,0 +1,39 @@
+package webui
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestLoginLimiter(t *testing.T) {
+	l := newLoginLimiter()
+	ip := "203.0.113.9"
+
+	for i := 0; i < loginMaxFails-1; i++ {
+		l.fail(ip)
+		if blocked, _ := l.blocked(ip); blocked {
+			t.Fatalf("blocked after %d failures", i+1)
+		}
+	}
+	l.fail(ip)
+	if blocked, _ := l.blocked(ip); !blocked {
+		t.Fatal("not blocked after reaching the limit")
+	}
+
+	l.reset(ip)
+	if blocked, _ := l.blocked(ip); blocked {
+		t.Fatal("still blocked after reset")
+	}
+}
+
+func TestLoginLimiterStaysBounded(t *testing.T) {
+	l := newLoginLimiter()
+	for i := 0; i < loginMaxTracked+100; i++ {
+		l.fail(strconv.Itoa(i))
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.fails) > loginMaxTracked || len(l.seen) > loginMaxTracked || len(l.until) > loginMaxTracked {
+		t.Fatalf("limiter grew past cap: fails=%d seen=%d until=%d", len(l.fails), len(l.seen), len(l.until))
+	}
+}

--- a/internal/webui/security_test.go
+++ b/internal/webui/security_test.go
@@ -2,30 +2,7 @@ package webui
 
 import (
 	"testing"
-	"time"
 )
-
-// Five failures lock the address out; a success wipes the slate.
-func TestLoginLimiter(t *testing.T) {
-	l := &loginLimiter{fails: map[string]int{}, until: map[string]time.Time{}}
-	ip := "203.0.113.9"
-
-	for i := 0; i < loginMaxFails-1; i++ {
-		l.fail(ip)
-		if b, _ := l.blocked(ip); b {
-			t.Fatalf("blocked after %d failures", i+1)
-		}
-	}
-	l.fail(ip)
-	if b, _ := l.blocked(ip); !b {
-		t.Fatal("not blocked after reaching the limit")
-	}
-
-	l.reset(ip)
-	if b, _ := l.blocked(ip); b {
-		t.Fatal("still blocked after reset")
-	}
-}
 
 // A code works exactly once; three wrong tries kill the pending login.
 func TestTwoFAStore(t *testing.T) {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -150,7 +150,8 @@ func (s *sessionStore) clear() {
 }
 
 type server struct {
-	sessions *sessionStore
+	sessions      *sessionStore
+	secureCookies bool
 }
 
 // password always reads the current password from disk, so a change made from
@@ -172,7 +173,7 @@ func Serve() error {
 	if err != nil {
 		return err
 	}
-	srv := &server{sessions: newSessionStore()}
+	srv := &server{sessions: newSessionStore(), secureCookies: cfg.HTTPS}
 
 	// The SOCKS5 relay, the watchdog, the Telegram bot and the alerts all
 	// deliberately run elsewhere — in the backpack-monitor service. See
@@ -222,12 +223,7 @@ func Serve() error {
 	mux.HandleFunc("/sw.js", handleServiceWorker)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Port)
-	httpServer := &http.Server{
-		Addr:         addr,
-		Handler:      mux,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 30 * time.Second,
-	}
+	httpServer := newPanelHTTPServer(addr, securePanelHTTP(mux))
 	if !cfg.HTTPS {
 		return httpServer.ListenAndServe()
 	}
@@ -309,10 +305,12 @@ func (s *server) handleLogin(w http.ResponseWriter, r *http.Request) {
 				int(left.Minutes())+1), http.StatusTooManyRequests)
 			return
 		}
-		r.ParseForm()
+		if !parseAuthForm(w, r) {
+			return
+		}
 		given := r.FormValue("password")
 		// Constant-time comparison + small delay to slow brute force.
-		if subtle.ConstantTimeCompare([]byte(given), []byte(s.password())) == 1 {
+		if passwordMatches(given, s.password()) {
 			limiter.reset(ip)
 			// With two-factor on, the password alone is only half the login.
 			if Load().TwoFA && telegramReady() {
@@ -324,16 +322,12 @@ func (s *server) handleLogin(w http.ResponseWriter, r *http.Request) {
 					http.StatusBadGateway)
 				return
 			}
+			if old, err := r.Cookie(sessionCookie); err == nil {
+				s.sessions.destroy(old.Value)
+			}
 			tok := s.sessions.create(ip)
 			notifyLogin(r)
-			http.SetCookie(w, &http.Cookie{
-				Name:     sessionCookie,
-				Value:    tok,
-				Path:     "/",
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-				MaxAge:   12 * 3600,
-			})
+			s.setAuthCookie(w, sessionCookie, tok, 12*time.Hour)
 			http.Redirect(w, r, "/", http.StatusSeeOther)
 			return
 		}
@@ -352,7 +346,7 @@ func (s *server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	if c, err := r.Cookie(sessionCookie); err == nil {
 		s.sessions.destroy(c.Value)
 	}
-	http.SetCookie(w, &http.Cookie{Name: sessionCookie, Value: "", Path: "/", MaxAge: -1})
+	s.clearAuthCookie(w, sessionCookie)
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 
@@ -526,6 +520,16 @@ func writeJSON(w http.ResponseWriter, v any) {
 
 func randomHex(n int) string {
 	b := make([]byte, n)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic("web panel: secure random source failed: " + err.Error())
+	}
 	return hex.EncodeToString(b)
+}
+
+func (s *server) setAuthCookie(w http.ResponseWriter, name, value string, ttl time.Duration) {
+	http.SetCookie(w, newAuthCookie(name, value, ttl, s.secureCookies))
+}
+
+func (s *server) clearAuthCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, expiredAuthCookie(name, s.secureCookies))
 }


### PR DESCRIPTION
## Summary
- use Secure/HttpOnly/SameSite=Strict auth cookies with explicit expiry
- add origin checks, security headers, request-size limits, and HTTP timeouts
- compare password hashes in constant time and rotate an existing session on login
- bound the per-IP login limiter so hostile source churn cannot grow memory forever

## Verification
- HTTP security tests repeated 100 times
- login limiter tests repeated 100 times
- Linux webui cross-build and go vet

## Compatibility
Secure cookies are enabled when the panel uses HTTPS; intentional plain-HTTP deployments remain usable.