### PR TITLE
fix: serialize legacy monitor state

### DIFF
--- a/internal/client/transport/kcp.go
+++ b/internal/client/transport/kcp.go
@@ -43,7 +43,6 @@ type KcpConfig struct {
 	Endpoints        *network.Endpoints
 	Token            string
 	SnifferLog       string
-	TunnelStatus     string
 	Sniffer          bool
 	KeepAlive        time.Duration
 	RetryInterval    time.Duration
@@ -150,7 +149,7 @@ func NewKcpClient(parentCtx context.Context, config *KcpConfig, logger *logrus.L
 	}
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -159,7 +158,7 @@ func (c *KcpTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = "Disconnected (" + c.transportLabel() + ")"
+	c.state.Usage().SetTunnelStatus("Disconnected (" + c.transportLabel() + ")")
 
 	go c.channelDialer()
 }
@@ -202,8 +201,8 @@ func (c *KcpTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	atomic.StoreInt32(&c.poolConnections, 0)
 	atomic.StoreInt32(&c.loadConnections, 0)
 	// The published pool figures belong to the run that just ended. Left
@@ -305,7 +304,7 @@ func (c *KcpTransport) channelDialer() {
 			c.state.SetConn(tunnelConn)
 			c.logger.Info("control channel established successfully")
 
-			c.config.TunnelStatus = "Connected (" + c.transportLabel() + ")"
+			c.state.Usage().SetTunnelStatus("Connected (" + c.transportLabel() + ")")
 
 			go c.poolMaintainer()
 			go c.channelHandler()

--- a/internal/client/transport/quic.go
+++ b/internal/client/transport/quic.go
@@ -49,7 +49,6 @@ type QuicConfig struct {
 	Endpoints      *network.Endpoints
 	Token          string
 	SnifferLog     string
-	TunnelStatus   string
 	Sniffer        bool
 	KeepAlive      time.Duration
 	RetryInterval  time.Duration
@@ -91,7 +90,7 @@ func NewQuicClient(parentCtx context.Context, config *QuicConfig, logger *logrus
 	}
 	// Seed the first generation through the same path a restart uses, so there is
 	// only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -112,7 +111,7 @@ func (c *QuicTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = "Disconnected (QUIC)"
+	c.state.Usage().SetTunnelStatus("Disconnected (QUIC)")
 
 	go c.channelDialer()
 }
@@ -154,8 +153,8 @@ func (c *QuicTransport) Restart() {
 
 	ctx, cancel := context.WithCancel(c.parentctx)
 
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	atomic.StoreInt32(&c.poolConnections, 0)
 	atomic.StoreInt32(&c.loadConnections, 0)
 	metrics.ClearPool()
@@ -245,7 +244,7 @@ func (c *QuicTransport) channelDialer() {
 			c.state.SetConn(control)
 			c.logger.Info("control channel established successfully")
 
-			c.config.TunnelStatus = "Connected (QUIC)"
+			c.state.Usage().SetTunnelStatus("Connected (QUIC)")
 
 			go c.poolMaintainer()
 			go c.channelHandler()

--- a/internal/client/transport/tcp.go
+++ b/internal/client/transport/tcp.go
@@ -44,7 +44,6 @@ type TcpConfig struct {
 	Endpoints      *network.Endpoints
 	Token          string
 	SnifferLog     string
-	TunnelStatus   string
 	KeepAlive      time.Duration
 	RetryInterval  time.Duration
 	DialTimeOut    time.Duration
@@ -93,7 +92,7 @@ func NewTCPClient(parentCtx context.Context, config *TcpConfig, logger *logrus.L
 
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -102,7 +101,7 @@ func (c *TcpTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = "Disconnected (TCP)"
+	c.state.Usage().SetTunnelStatus("Disconnected (TCP)")
 
 	go c.channelDialer()
 }
@@ -145,8 +144,8 @@ func (c *TcpTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	// The next control channel issues its own nonce; carrying this one over
 	// would have the pool announcing a value the server has already forgotten.
 	c.poolNonce.Clear()
@@ -247,7 +246,7 @@ func (c *TcpTransport) channelDialer() {
 				c.state.SetConn(tunnelTCPConn)
 				c.logger.Info("control channel established successfully")
 
-				c.config.TunnelStatus = "Connected (TCP)"
+				c.state.Usage().SetTunnelStatus("Connected (TCP)")
 				go c.poolMaintainer()
 				go c.channelHandler()
 

--- a/internal/client/transport/tcpmux.go
+++ b/internal/client/transport/tcpmux.go
@@ -51,7 +51,6 @@ type TcpMuxConfig struct {
 	Endpoints        *network.Endpoints
 	Token            string
 	SnifferLog       string
-	TunnelStatus     string
 	Nodelay          bool
 	Sniffer          bool
 	KeepAlive        time.Duration
@@ -97,7 +96,7 @@ func NewMuxClient(parentCtx context.Context, config *TcpMuxConfig, logger *logru
 
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -106,7 +105,7 @@ func (c *TcpMuxTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = "Disconnected (TCPMUX)"
+	c.state.Usage().SetTunnelStatus("Disconnected (TCPMUX)")
 
 	go c.channelDialer()
 }
@@ -150,8 +149,8 @@ func (c *TcpMuxTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	// The next control channel issues its own nonce; carrying this one over
 	// would have the pool announcing a value the server has already forgotten.
 	c.poolNonce.Clear()
@@ -243,7 +242,7 @@ func (c *TcpMuxTransport) channelDialer() {
 				c.state.SetConn(tunnelConn)
 				c.logger.Infof("control channel established successfully (mux version %d)", c.muxVersion.Load())
 
-				c.config.TunnelStatus = "Connected (TCPMux)"
+				c.state.Usage().SetTunnelStatus("Connected (TCPMux)")
 
 				go c.poolMaintainer()
 				go c.channelHandler()

--- a/internal/client/transport/udp.go
+++ b/internal/client/transport/udp.go
@@ -31,7 +31,6 @@ type UdpConfig struct {
 	Endpoints      *network.Endpoints
 	Token          string
 	SnifferLog     string
-	TunnelStatus   string
 	RetryInterval  time.Duration
 	DialTimeOut    time.Duration
 	ConnPoolSize   int
@@ -62,7 +61,7 @@ func NewUDPClient(parentCtx context.Context, config *UdpConfig, logger *logrus.L
 
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -71,7 +70,7 @@ func (c *UdpTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = "Disconnected (UDP)"
+	c.state.Usage().SetTunnelStatus("Disconnected (UDP)")
 
 	go c.channelDialer()
 }
@@ -115,8 +114,8 @@ func (c *UdpTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	atomic.StoreInt32(&c.poolConnections, 0)
 	atomic.StoreInt32(&c.loadConnections, 0)
 	drain(c.controlFlow)
@@ -189,7 +188,7 @@ func (c *UdpTransport) channelDialer() {
 				c.state.SetConn(tunnelTCPConn)
 				c.logger.Info("control channel established successfully")
 
-				c.config.TunnelStatus = "Connected (UDP)"
+				c.state.Usage().SetTunnelStatus("Connected (UDP)")
 
 				go c.poolMaintainer()
 				go c.channelHandler()

--- a/internal/client/transport/ws.go
+++ b/internal/client/transport/ws.go
@@ -36,7 +36,6 @@ type WsConfig struct {
 	Endpoints      *network.Endpoints
 	Token          string
 	SnifferLog     string
-	TunnelStatus   string
 	Nodelay        bool
 	Sniffer        bool
 	KeepAlive      time.Duration
@@ -71,7 +70,7 @@ func NewWSClient(parentCtx context.Context, config *WsConfig, logger *logrus.Log
 
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -81,7 +80,7 @@ func (c *WsTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", c.config.Mode)
+	c.state.Usage().SetTunnelStatus(fmt.Sprintf("Disconnected (%s)", c.config.Mode))
 
 	go c.channelDialer()
 
@@ -125,8 +124,8 @@ func (c *WsTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	atomic.StoreInt32(&c.poolConnections, 0)
 	atomic.StoreInt32(&c.loadConnections, 0)
 	drain(c.controlFlow)
@@ -164,7 +163,7 @@ func (c *WsTransport) channelDialer() {
 			c.state.SetWSConn(tunnelWSConn)
 			c.logger.Info("control channel established successfully")
 
-			c.config.TunnelStatus = fmt.Sprintf("Connected (%s)", c.config.Mode)
+			c.state.Usage().SetTunnelStatus(fmt.Sprintf("Connected (%s)", c.config.Mode))
 
 			go c.poolMaintainer()
 			go c.channelHandler()

--- a/internal/client/transport/wsmux.go
+++ b/internal/client/transport/wsmux.go
@@ -38,7 +38,6 @@ type WsMuxConfig struct {
 	Endpoints        *network.Endpoints
 	Token            string
 	SnifferLog       string
-	TunnelStatus     string
 	Nodelay          bool
 	Sniffer          bool
 	KeepAlive        time.Duration
@@ -85,7 +84,7 @@ func NewWSMuxClient(parentCtx context.Context, config *WsMuxConfig, logger *logr
 
 	// Seed the first generation through the same path a restart uses, so
 	// there is only one way this state is ever published.
-	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger))
+	client.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger))
 	return client
 }
 
@@ -94,7 +93,7 @@ func (c *WsMuxTransport) Start() {
 		go c.state.Usage().Monitor()
 	}
 
-	c.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", c.config.Mode)
+	c.state.Usage().SetTunnelStatus(fmt.Sprintf("Disconnected (%s)", c.config.Mode))
 
 	go c.channelDialer()
 }
@@ -138,8 +137,8 @@ func (c *WsMuxTransport) Restart() {
 
 	// Publish the whole new generation at once: a reader must never see
 	// the new context paired with the old monitor, or vice versa.
-	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, &c.config.TunnelStatus, c.logger))
-	c.config.TunnelStatus = ""
+	c.state.Reset(ctx, cancel, web.NewDataStore(fmt.Sprintf(":%v", c.config.WebPort), ctx, c.config.SnifferLog, c.config.Sniffer, c.logger))
+	c.state.Usage().SetTunnelStatus("")
 	atomic.StoreInt32(&c.poolConnections, 0)
 	atomic.StoreInt32(&c.loadConnections, 0)
 	// The published pool figures belong to the run that just ended. Left
@@ -182,7 +181,7 @@ func (c *WsMuxTransport) channelDialer() {
 			c.state.SetWSConn(tunnelWSConn)
 			c.logger.Info("control channel established successfully")
 
-			c.config.TunnelStatus = fmt.Sprintf("Connected (%s)", c.config.Mode)
+			c.state.Usage().SetTunnelStatus(fmt.Sprintf("Connected (%s)", c.config.Mode))
 
 			go c.poolMaintainer()
 			go c.channelHandler()

--- a/internal/server/transport/kcp.go
+++ b/internal/server/transport/kcp.go
@@ -65,7 +65,6 @@ type KcpTransport struct {
 
 type KcpConfig struct {
 	BindAddr         string
-	TunnelStatus     string
 	SnifferLog       string
 	Token            string
 	Ports            []string
@@ -178,7 +177,7 @@ func NewKcpServer(parentCtx context.Context, config *KcpConfig, logger *logrus.L
 		handshakeChannel: make(chan net.Conn),
 		localChannel:     make(chan LocalTCPConn, config.ChannelSize),
 		reqNewConnChan:   make(chan struct{}, config.ChannelSize),
-		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:           newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 	}
 }
@@ -200,14 +199,14 @@ func (s *KcpTransport) Start() {
 	if s.config.WebPort > 0 {
 		go g.usageMonitor.Monitor()
 	}
-	s.config.TunnelStatus = "Disconnected (" + s.transportLabel() + ")"
+	s.usageMonitor.SetTunnelStatus("Disconnected (" + s.transportLabel() + ")")
 
 	go s.tunnelListener(g)
 
 	s.channelHandshake(g)
 
 	if s.controlChannel.IsSet() {
-		s.config.TunnelStatus = "Connected (" + s.transportLabel() + ")"
+		s.usageMonitor.SetTunnelStatus("Connected (" + s.transportLabel() + ")")
 
 		numCPU := runtime.NumCPU()
 		if numCPU > 4 {
@@ -273,8 +272,8 @@ func (s *KcpTransport) Restart() {
 	// The peer is gone until a new control channel arrives; a stale address
 	// would be shown as if it were current.
 	metrics.ClearPeer()
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 	// Stored atomically, like every other access: the goroutines of the run
 	// being replaced may still be counting while this resets them.
 	atomic.StoreInt32(&s.streamCounter, 0)

--- a/internal/server/transport/quic.go
+++ b/internal/server/transport/quic.go
@@ -55,7 +55,6 @@ type QuicTransport struct {
 
 type QuicConfig struct {
 	BindAddr      string
-	TunnelStatus  string
 	SnifferLog    string
 	Token         string
 	Ports         []string
@@ -105,7 +104,7 @@ func NewQuicServer(parentCtx context.Context, config *QuicConfig, logger *logrus
 		tunnelChannel:  make(chan net.Conn, config.ChannelSize),
 		localChannel:   make(chan LocalTCPConn, config.ChannelSize),
 		reqNewConnChan: make(chan struct{}, config.ChannelSize),
-		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:         newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 	}
 }
@@ -122,7 +121,7 @@ func (s *QuicTransport) Start() {
 	if s.config.WebPort > 0 {
 		go g.usageMonitor.Monitor()
 	}
-	s.config.TunnelStatus = "Disconnected (QUIC)"
+	s.usageMonitor.SetTunnelStatus("Disconnected (QUIC)")
 
 	// handshakeChannel is local to this run: the accept loop publishes the
 	// control stream onto it, and channelHandshake below takes it. Keeping it off
@@ -142,7 +141,7 @@ func (s *QuicTransport) Start() {
 		s.logger.Info("control channel successfully established.")
 	}
 
-	s.config.TunnelStatus = "Connected (QUIC)"
+	s.usageMonitor.SetTunnelStatus("Connected (QUIC)")
 
 	numCPU := runtime.NumCPU()
 	if numCPU > 4 {
@@ -201,8 +200,8 @@ func (s *QuicTransport) Restart() {
 	// The peer is gone until a new control channel arrives; a stale address would
 	// be shown as if it were current.
 	metrics.ClearPeer()
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 
 	s.logger.SetLevel(level)
 

--- a/internal/server/transport/tcp.go
+++ b/internal/server/transport/tcp.go
@@ -58,7 +58,6 @@ type TcpConfig struct {
 	BindAddr      string
 	Token         string
 	SnifferLog    string
-	TunnelStatus  string
 	Ports         []string
 	Nodelay       bool
 	Sniffer       bool
@@ -98,7 +97,7 @@ func NewTCPServer(parentCtx context.Context, config *TcpConfig, logger *logrus.L
 		// between the listener starting and channelHandshake reaching its
 		// select is held rather than dropped.
 		handshakeChannel: make(chan controlCandidate, 1),
-		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:           newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 		rtt:              0,
 	}
@@ -120,7 +119,7 @@ func (s *TcpTransport) Start() {
 		usageMonitor:     s.usageMonitor,
 	}
 
-	s.config.TunnelStatus = "Disconnected (TCP)"
+	s.usageMonitor.SetTunnelStatus("Disconnected (TCP)")
 
 	if s.config.WebPort > 0 {
 		go g.usageMonitor.Monitor()
@@ -131,7 +130,7 @@ func (s *TcpTransport) Start() {
 	s.channelHandshake(g)
 
 	if s.controlChannel.IsSet() {
-		s.config.TunnelStatus = "Connected (TCP)"
+		s.usageMonitor.SetTunnelStatus("Connected (TCP)")
 
 		numCPU := runtime.NumCPU()
 		if numCPU > 4 {
@@ -194,8 +193,8 @@ func (s *TcpTransport) Restart() {
 	s.localChannel = make(chan LocalTCPConn, s.config.ChannelSize)
 	s.reqNewConnChan = make(chan struct{}, s.config.ChannelSize)
 	s.handshakeChannel = make(chan controlCandidate, 1)
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 	s.controlChannel.Clear()
 	// The next run issues its own nonce, so connections still carrying this
 	// one must stop being accepted the moment the run ends.

--- a/internal/server/transport/tcpmux.go
+++ b/internal/server/transport/tcpmux.go
@@ -64,7 +64,6 @@ type TcpMuxTransport struct {
 
 type TcpMuxConfig struct {
 	BindAddr         string
-	TunnelStatus     string
 	SnifferLog       string
 	Token            string
 	Ports            []string
@@ -137,7 +136,7 @@ func NewTcpMuxServer(parentCtx context.Context, config *TcpMuxConfig, logger *lo
 		reqNewConnChan:   make(chan struct{}, config.ChannelSize),
 		streamCounter:    0,
 		sessionCounter:   0,
-		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:     web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:           newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 	}
 
@@ -161,14 +160,14 @@ func (s *TcpMuxTransport) Start() {
 	if s.config.WebPort > 0 {
 		go g.usageMonitor.Monitor()
 	}
-	s.config.TunnelStatus = "Disconnected (TCPMux)"
+	s.usageMonitor.SetTunnelStatus("Disconnected (TCPMux)")
 
 	go s.tunnelListener(g)
 
 	s.channelHandshake(g)
 
 	if s.controlChannel.IsSet() {
-		s.config.TunnelStatus = "Connected (TCPMux)"
+		s.usageMonitor.SetTunnelStatus("Connected (TCPMux)")
 
 		numCPU := runtime.NumCPU()
 		if numCPU > 4 {
@@ -239,8 +238,8 @@ func (s *TcpMuxTransport) Restart() {
 	// one or the same build.
 	s.poolNonce.Clear()
 	s.muxVersion.Store(0)
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 	// Stored atomically, like every other access: the goroutines of the run
 	// being replaced may still be counting while this resets them.
 	atomic.StoreInt32(&s.streamCounter, 0)

--- a/internal/server/transport/udp.go
+++ b/internal/server/transport/udp.go
@@ -42,15 +42,14 @@ type UdpTransport struct {
 }
 
 type UdpConfig struct {
-	BindAddr     string
-	Token        string
-	SnifferLog   string
-	TunnelStatus string
-	Ports        []string
-	Sniffer      bool
-	Heartbeat    time.Duration // in seconds, for udp conn and control channel
-	ChannelSize  int
-	WebPort      int
+	BindAddr    string
+	Token       string
+	SnifferLog  string
+	Ports       []string
+	Sniffer     bool
+	Heartbeat   time.Duration // in seconds, for udp conn and control channel
+	ChannelSize int
+	WebPort     int
 	// SO_RCVBUF/SO_SNDBUF size the datagram sockets. The kernel default is a few
 	// hundred KB, which a datagram flood — a speed test, a busy game server —
 	// overruns in a blink, and the packets it cannot hold are dropped before any
@@ -75,7 +74,7 @@ func NewUDPServer(parentCtx context.Context, config *UdpConfig, logger *logrus.L
 		activeConnections: map[string]*TunnelUDPConn{},
 		activeMu:          sync.Mutex{},
 		reqNewConnChan:    make(chan struct{}, config.ChannelSize),
-		usageMonitor:      web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:      web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		rtt:               0,
 	}
 
@@ -93,7 +92,7 @@ func (s *UdpTransport) Start() {
 		usageMonitor:   s.usageMonitor,
 	}
 
-	s.config.TunnelStatus = "Disconnected (UDP)"
+	s.usageMonitor.SetTunnelStatus("Disconnected (UDP)")
 
 	if s.config.WebPort > 0 {
 		go g.usageMonitor.Monitor()
@@ -146,8 +145,8 @@ func (s *UdpTransport) Restart() {
 	// Re-initialize variables
 	s.tunnelChannel = make(chan *TunnelUDPConn, s.config.ChannelSize)
 	s.reqNewConnChan = make(chan struct{}, s.config.ChannelSize)
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 	s.controlChannel.Clear()
 	s.activeConnections = map[string]*TunnelUDPConn{}
 	s.activeMu = sync.Mutex{}

--- a/internal/server/transport/ws.go
+++ b/internal/server/transport/ws.go
@@ -56,7 +56,6 @@ type WsConfig struct {
 	ACMEDomain   string // non-empty switches to Let's Encrypt for this domain
 	ACMEEmail    string
 	ACMECacheDir string
-	TunnelStatus string
 	Token        string
 	SimpleAuth   bool
 	Ports        []string
@@ -88,7 +87,7 @@ func NewWSServer(parentCtx context.Context, config *WsConfig, logger *logrus.Log
 		tunnelChannel:  make(chan TunnelChannel, config.ChannelSize),
 		localChannel:   make(chan LocalTCPConn, config.ChannelSize),
 		reqNewConnChan: make(chan struct{}, config.ChannelSize),
-		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:         newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 	}
 
@@ -113,7 +112,7 @@ func (s *WsTransport) Start() {
 		go g.usageMonitor.Monitor()
 	}
 
-	s.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", s.config.Mode)
+	s.usageMonitor.SetTunnelStatus(fmt.Sprintf("Disconnected (%s)", s.config.Mode))
 
 	go s.tunnelListener(g)
 
@@ -163,8 +162,8 @@ func (s *WsTransport) Restart() {
 	s.localChannel = make(chan LocalTCPConn, s.config.ChannelSize)
 	s.reqNewConnChan = make(chan struct{}, s.config.ChannelSize)
 	s.controlChannel.Clear()
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 
 	// set the log level again
 	s.logger.SetLevel(level)
@@ -307,7 +306,7 @@ func (s *WsTransport) tunnelListener(g *wsGen) {
 					go s.handleLoop(g)
 				}
 
-				s.config.TunnelStatus = fmt.Sprintf("Connected (%s)", s.config.Mode)
+				s.usageMonitor.SetTunnelStatus(fmt.Sprintf("Connected (%s)", s.config.Mode))
 
 			} else if strings.HasPrefix(r.URL.Path, "/tunnel") {
 				wsConn := TunnelChannel{

--- a/internal/server/transport/wsmux.go
+++ b/internal/server/transport/wsmux.go
@@ -64,7 +64,6 @@ type WsMuxConfig struct {
 	ACMEDomain       string // non-empty switches to Let's Encrypt for this domain
 	ACMEEmail        string
 	ACMECacheDir     string
-	TunnelStatus     string
 	Ports            []string
 	Nodelay          bool
 	Sniffer          bool
@@ -109,7 +108,7 @@ func NewWSMuxServer(parentCtx context.Context, config *WsMuxConfig, logger *logr
 		reqNewConnChan: make(chan struct{}, config.ChannelSize),
 		streamCounter:  0,
 		sessionCounter: 0,
-		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, &config.TunnelStatus, logger),
+		usageMonitor:   web.NewDataStore(fmt.Sprintf(":%v", config.WebPort), ctx, config.SnifferLog, config.Sniffer, logger),
 		limits:         newLimiter(Limits{MaxConnections: config.MaxConnections, BandwidthMbps: config.BandwidthMbps}),
 	}
 
@@ -134,7 +133,7 @@ func (s *WsMuxTransport) Start() {
 		go g.usageMonitor.Monitor()
 	}
 
-	s.config.TunnelStatus = fmt.Sprintf("Disconnected (%s)", s.config.Mode)
+	s.usageMonitor.SetTunnelStatus(fmt.Sprintf("Disconnected (%s)", s.config.Mode))
 
 	go s.tunnelListener(g)
 
@@ -186,8 +185,8 @@ func (s *WsMuxTransport) Restart() {
 	s.localChannel = make(chan LocalTCPConn, s.config.ChannelSize)
 	s.reqNewConnChan = make(chan struct{}, s.config.ChannelSize)
 	s.controlChannel.Clear()
-	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, &s.config.TunnelStatus, s.logger)
-	s.config.TunnelStatus = ""
+	s.usageMonitor = web.NewDataStore(fmt.Sprintf(":%v", s.config.WebPort), ctx, s.config.SnifferLog, s.config.Sniffer, s.logger)
+	s.usageMonitor.SetTunnelStatus("")
 	// Stored atomically, like every other access: the goroutines of the run
 	// being replaced may still be counting while this resets them.
 	atomic.StoreInt32(&s.streamCounter, 0)
@@ -335,7 +334,7 @@ func (s *WsMuxTransport) tunnelListener(g *wsMuxGen) {
 					go s.handleLoop(g)
 				}
 
-				s.config.TunnelStatus = fmt.Sprintf("Connected (%s)", s.config.Mode)
+				s.usageMonitor.SetTunnelStatus(fmt.Sprintf("Connected (%s)", s.config.Mode))
 
 			} else if strings.HasPrefix(r.URL.Path, "/tunnel") {
 				session, err := smux.Client(conn.NetConn(), s.smuxConfig)

--- a/internal/web/concurrency_test.go
+++ b/internal/web/concurrency_test.go
@@ -1,0 +1,83 @@
+package web
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestTunnelStatusIsSafeForConcurrentUpdates(t *testing.T) {
+	m := &Usage{}
+	var workers sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		workers.Add(1)
+		go func(worker int) {
+			defer workers.Done()
+			for update := 0; update < 1000; update++ {
+				m.SetTunnelStatus(fmt.Sprintf("%d-%d", worker, update))
+				_ = m.loadTunnelStatus()
+			}
+		}(worker)
+	}
+	workers.Wait()
+	if m.loadTunnelStatus() == "" {
+		t.Fatal("concurrent status updates were lost")
+	}
+}
+
+func TestUsageFileReadsAndWritesAreSerialized(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	m := &Usage{snifferLog: filepath.Join(t.TempDir(), "usage.json"), logger: logger}
+
+	var workers sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		workers.Add(1)
+		go func(worker int) {
+			defer workers.Done()
+			for update := 0; update < 25; update++ {
+				m.AddOrUpdatePort(1000+worker, 1)
+				m.saveUsageData()
+				_ = m.getUsageFromFile()
+			}
+		}(worker)
+	}
+	workers.Wait()
+	if got := m.getUsageFromFile(); len(got) == 0 {
+		t.Fatal("serialized usage file lost all records")
+	}
+}
+
+func TestCachedStatsKeepLiveTunnelFields(t *testing.T) {
+	m := &Usage{
+		cachedStats: &SystemStats{CPUUsage: "cached", TunnelStatus: "stale", TunnelTraffic: "stale"},
+		statsAt:     time.Now(),
+	}
+	m.SetTunnelStatus("Connected (TCP)")
+	m.totalTraffic.Store(2048)
+
+	stats, err := m.getSystemStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.CPUUsage != "cached" || stats.TunnelStatus != "Connected (TCP)" || stats.TunnelTraffic != "2.00 KB" {
+		t.Fatalf("unexpected cached snapshot: %+v", stats)
+	}
+	if stats == m.cachedStats {
+		t.Fatal("cached stats escaped without a defensive copy")
+	}
+}
+
+func TestCounterDeltaHandlesCounterReset(t *testing.T) {
+	if got := counterDelta(125, 100); got != 25 {
+		t.Fatalf("counter delta = %d, want 25", got)
+	}
+	if got := counterDelta(5, 100); got != 0 {
+		t.Fatalf("reset counter delta = %d, want 0", got)
+	}
+}

--- a/internal/web/sniffer.go
+++ b/internal/web/sniffer.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -30,8 +31,12 @@ type Usage struct {
 	sniffer      bool
 	snifferLog   string
 	mu           sync.Mutex
-	totalTraffic uint64
-	tunnelStatus *string
+	fileMu       sync.Mutex
+	statsMu      sync.Mutex
+	totalTraffic atomic.Uint64
+	tunnelStatus atomic.Value
+	cachedStats  *SystemStats
+	statsAt      time.Time
 }
 
 type PortUsage struct {
@@ -53,20 +58,33 @@ type SystemStats struct {
 	AllConnections string `json:"allConnections"`
 }
 
-func NewDataStore(listenAddr string, shutdownCtx context.Context, snifferLog string, sniffer bool, tunnelStatus *string, logger *logrus.Logger) *Usage {
+func NewDataStore(listenAddr string, shutdownCtx context.Context, snifferLog string, sniffer bool, logger *logrus.Logger) *Usage {
 	ctx, cancel := context.WithCancel(shutdownCtx)
 	u := &Usage{
-		listenAddr:   listenAddr,
-		shutdownCtx:  ctx,
-		cancelFunc:   cancel,
-		logger:       logger,
-		sniffer:      sniffer,
-		snifferLog:   snifferLog,
-		tunnelStatus: tunnelStatus,
-		mu:           sync.Mutex{},
-		totalTraffic: 0,
+		listenAddr:  listenAddr,
+		shutdownCtx: ctx,
+		cancelFunc:  cancel,
+		logger:      logger,
+		sniffer:     sniffer,
+		snifferLog:  snifferLog,
+		mu:          sync.Mutex{},
 	}
+	u.tunnelStatus.Store("")
 	return u
+}
+
+const systemStatsTTL = 5 * time.Second
+
+func (m *Usage) SetTunnelStatus(status string) {
+	m.tunnelStatus.Store(status)
+}
+
+func (m *Usage) loadTunnelStatus() string {
+	status := m.tunnelStatus.Load()
+	if status == nil {
+		return ""
+	}
+	return status.(string)
 }
 
 func (m *Usage) Monitor() {
@@ -102,7 +120,7 @@ func (m *Usage) Monitor() {
 			for {
 				select {
 				case <-ticker.C:
-					go m.saveUsageData()
+					m.saveUsageData()
 				case <-m.shutdownCtx.Done():
 					return
 				}
@@ -176,15 +194,22 @@ func (m *Usage) AddOrUpdatePort(port int, usage uint64) {
 }
 
 func (m *Usage) saveUsageData() {
+	m.fileMu.Lock()
+	defer m.fileMu.Unlock()
+
 	// Step 1: Load existing usage data from the JSON file
 	var existingUsageData []PortUsage
 	file, err := os.Open(m.snifferLog)
 	if err == nil {
 		// If the file exists, decode the JSON data into existingUsageData
-		defer file.Close()
-		err = json.NewDecoder(file).Decode(&existingUsageData)
-		if err != nil {
-			m.logger.Errorf("error decoding JSON data: %v", err)
+		decodeErr := json.NewDecoder(file).Decode(&existingUsageData)
+		closeErr := file.Close()
+		if decodeErr != nil {
+			m.logger.Errorf("error decoding JSON data: %v", decodeErr)
+			return
+		}
+		if closeErr != nil {
+			m.logger.Errorf("error closing JSON file: %v", closeErr)
 			return
 		}
 	} else if !os.IsNotExist(err) {
@@ -216,14 +241,14 @@ func (m *Usage) saveUsageData() {
 		}
 	}
 
-	m.totalTraffic = 0
-
 	// Step 4: Convert the map back to a slice
 	var mergedUsageData []PortUsage
+	var totalTraffic uint64
 	for _, usage := range usageMap {
 		mergedUsageData = append(mergedUsageData, usage)
-		m.totalTraffic += usage.Usage
+		totalTraffic += usage.Usage
 	}
+	m.totalTraffic.Store(totalTraffic)
 
 	// Step 5: Convert merged data to JSON
 	data, err := json.MarshalIndent(mergedUsageData, "", "  ")
@@ -240,6 +265,9 @@ func (m *Usage) saveUsageData() {
 }
 
 func (m *Usage) getUsageFromFile() []PortUsage {
+	m.fileMu.Lock()
+	defer m.fileMu.Unlock()
+
 	// Check if the file exists
 	if _, err := os.Stat(m.snifferLog); os.IsNotExist(err) {
 		// If the file does not exist, create it and write "null"
@@ -254,6 +282,9 @@ func (m *Usage) getUsageFromFile() []PortUsage {
 			m.logger.Errorf("error writing 'null' to the file: %v", err)
 			file.Close()
 			return nil
+		}
+		if err := file.Close(); err != nil {
+			m.logger.Errorf("error closing JSON file: %v", err)
 		}
 
 		return nil
@@ -347,6 +378,28 @@ func (m *Usage) convertBytesToReadable(bytes uint64) string {
 }
 
 func (m *Usage) getSystemStats() (*SystemStats, error) {
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	if m.cachedStats != nil && time.Since(m.statsAt) < systemStatsTTL {
+		return m.statsSnapshot(m.cachedStats), nil
+	}
+	stats, err := m.collectSystemStats()
+	if err != nil {
+		return nil, err
+	}
+	m.cachedStats = stats
+	m.statsAt = time.Now()
+	return m.statsSnapshot(stats), nil
+}
+
+func (m *Usage) statsSnapshot(stats *SystemStats) *SystemStats {
+	copy := *stats
+	copy.TunnelStatus = m.loadTunnelStatus()
+	copy.TunnelTraffic = m.convertBytesToReadable(m.totalTraffic.Load())
+	return &copy
+}
+
+func (m *Usage) collectSystemStats() (*SystemStats, error) {
 
 	// Get initial network stats
 	initialStats, err := m.getNetworkStats()
@@ -367,6 +420,9 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 	cpuPercent, err := cpu.Percent(0, false)
 	if err != nil {
 		return nil, err
+	}
+	if len(cpuPercent) == 0 {
+		return nil, fmt.Errorf("no CPU usage samples found")
 	}
 
 	// Get RAM usage
@@ -392,6 +448,9 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(netStats) == 0 {
+		return nil, fmt.Errorf("no network IO counters found")
+	}
 
 	// Get all active network connections (TCP, UDP, etc.)
 	connections, err := net.Connections("all")
@@ -400,11 +459,11 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 	}
 
 	// Calculate upload and download speeds
-	uploadSpeed := float64(finalStats.BytesSent - initialStats.BytesSent)
-	downloadSpeed := float64(finalStats.BytesRecv - initialStats.BytesRecv)
+	uploadSpeed := float64(counterDelta(finalStats.BytesSent, initialStats.BytesSent))
+	downloadSpeed := float64(counterDelta(finalStats.BytesRecv, initialStats.BytesRecv))
 
 	stats := &SystemStats{
-		TunnelStatus:   *m.tunnelStatus,
+		TunnelStatus:   m.loadTunnelStatus(),
 		CPUUsage:       m.formatFloat(cpuPercent[0]),
 		RAMUsage:       m.convertBytesToReadable(memStats.Used),
 		DiskUsage:      m.convertBytesToReadable(diskStats.Used),
@@ -412,12 +471,19 @@ func (m *Usage) getSystemStats() (*SystemStats, error) {
 		NetworkTraffic: m.convertBytesToReadable(netStats[0].BytesSent + netStats[0].BytesRecv),
 		DownloadSpeed:  m.formatSpeed(downloadSpeed),
 		UploadSpeed:    m.formatSpeed(uploadSpeed),
-		TunnelTraffic:  m.convertBytesToReadable(m.totalTraffic),
+		TunnelTraffic:  m.convertBytesToReadable(m.totalTraffic.Load()),
 		Sniffer:        map[bool]string{true: "Running", false: "Not running"}[m.sniffer],
 		AllConnections: fmt.Sprintf("%d", len(connections)),
 	}
 
 	return stats, nil
+}
+
+func counterDelta(current, previous uint64) uint64 {
+	if current < previous {
+		return 0
+	}
+	return current - previous
 }
 
 func (m *Usage) formatSpeed(bytesPerSec float64) string {


### PR DESCRIPTION
## Summary
- replace the shared tunnel-status string with atomic monitor-owned state
- serialize usage-file reads/writes and close files before replacement
- cache expensive system-stat collection with single-flight behavior
- guard counter resets and empty CPU/network samples
- remove the obsolete shared status field across all transports

## Verification
- concurrency/cache/file tests repeated 10-20 times
- Linux cross-build and go vet for web and every client/server transport

## Why this matters
The stats endpoint raced transport status writes, allowed overlapping file I/O, and could launch repeated one-second system scans under polling load.