### PR TITLE
fix: publish backups atomically

### DIFF
--- a/internal/manage/backup.go
+++ b/internal/manage/backup.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -16,17 +15,8 @@ import (
 	"github.com/backpack/backpack/internal/schedule"
 )
 
-// backupMetaName is a synthetic entry stored inside the archive (not written to
-// disk on restore) that captures settings living outside ConfigDir — currently
-// the auto-refresh interval, which is kept in the crontab.
-const backupMetaName = ".backpack-backup.json"
-
 // backupMeta is the sidecar metadata embedded in every backup archive.
-type backupMeta struct {
-	Version          string `json:"version"`
-	Created          string `json:"created"`
-	AutoRefreshHours int    `json:"auto_refresh_hours"`
-}
+type backupMeta = archiveMetadata
 
 // RestoreResult summarises what a restore put back in place.
 type RestoreResult struct {
@@ -47,107 +37,26 @@ type RestoreResult struct {
 // recorded install path) plus a small sidecar capturing the auto-refresh
 // schedule, to w. It is the single source for both the CLI and web downloads.
 func WriteBackup(w io.Writer) error {
-	gz := gzip.NewWriter(w)
-	defer gz.Close()
-	tw := tar.NewWriter(gz)
-	defer tw.Close()
+	return writeBackupArchive(w, app.ConfigDir, currentBackupMeta())
+}
 
-	// Sidecar metadata for settings that don't live under ConfigDir.
-	meta := backupMeta{
+func currentBackupMeta() backupMeta {
+	return backupMeta{
 		Version:          app.Version,
 		Created:          time.Now().UTC().Format(time.RFC3339),
 		AutoRefreshHours: schedule.AutoRefreshHours(),
 	}
-	metaJSON, _ := json.MarshalIndent(meta, "", "  ")
-	if err := tw.WriteHeader(&tar.Header{
-		Name: backupMetaName,
-		Mode: 0600,
-		Size: int64(len(metaJSON)),
-	}); err != nil {
-		return err
-	}
-	if _, err := tw.Write(metaJSON); err != nil {
-		return err
-	}
-
-	// Walk the config directory and add every file, preserving relative paths
-	// and permissions (so 0600 key/config files stay 0600 on restore).
-	root := app.ConfigDir
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return nil
-		}
-		hdr, err := tar.FileInfoHeader(info, "")
-		if err != nil {
-			return err
-		}
-		hdr.Name = filepath.ToSlash(rel)
-		if info.IsDir() {
-			hdr.Name += "/"
-		}
-		if err := tw.WriteHeader(hdr); err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		_, err = io.Copy(tw, f)
-		return err
-	})
 }
 
 // backupRetention is how many backup archives are kept in the backup folder;
 // older ones are pruned automatically so backups never fill the disk.
 const backupRetention = 10
 
-// pruneBackups deletes all but the newest backupRetention archives in dir.
-func pruneBackups(dir string) {
-	matches, _ := filepath.Glob(filepath.Join(dir, "backpack-backup-*.tar.gz"))
-	if len(matches) <= backupRetention {
-		return
-	}
-	// Names are timestamped, so lexical order is chronological.
-	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
-	for _, old := range matches[backupRetention:] {
-		os.Remove(old)
-	}
-}
-
 // BackupToFile writes a timestamped backup archive into dir and returns its
 // path. dir is created if missing, and old archives beyond the retention limit
 // are pruned.
 func BackupToFile(dir string) (string, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", err
-	}
-	name := fmt.Sprintf("backpack-backup-%s.tar.gz", time.Now().Format("20060102-150405"))
-	path := filepath.Join(dir, name)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
-	if err != nil {
-		return "", err
-	}
-	if err := WriteBackup(f); err != nil {
-		f.Close()
-		os.Remove(path)
-		return "", err
-	}
-	if err := f.Close(); err != nil {
-		return "", err
-	}
-	pruneBackups(dir)
-	return path, nil
+	return publishBackupFile(dir, app.ConfigDir, currentBackupMeta(), backupRetention)
 }
 
 // Restore reads a backup archive produced by WriteBackup, extracts it into the

--- a/internal/manage/backup_archive.go
+++ b/internal/manage/backup_archive.go
@@ -1,0 +1,151 @@
+package manage
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// archiveMetadata captures settings that live outside ConfigDir. Its synthetic
+// entry is parsed on restore but is never written into the configuration tree.
+type archiveMetadata struct {
+	Version          string `json:"version"`
+	Created          string `json:"created"`
+	AutoRefreshHours int    `json:"auto_refresh_hours"`
+}
+
+const backupMetaName = ".backpack-backup.json"
+
+// writeBackupArchive closes every layer explicitly so a short write while tar
+// or gzip is flushing cannot be reported as a successful backup.
+func writeBackupArchive(w io.Writer, root string, meta archiveMetadata) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return fmt.Errorf("encode backup metadata: %w", err)
+	}
+	if err = tw.WriteHeader(&tar.Header{
+		Name: backupMetaName,
+		Mode: 0600,
+		Size: int64(len(metaJSON)),
+	}); err != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return fmt.Errorf("write backup metadata header: %w", err)
+	}
+	if _, err = tw.Write(metaJSON); err != nil {
+		_ = tw.Close()
+		_ = gz.Close()
+		return fmt.Errorf("write backup metadata: %w", err)
+	}
+
+	walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported file type in config directory: %s", path)
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if info.IsDir() {
+			hdr.Name += "/"
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if err := tw.Close(); walkErr == nil && err != nil {
+		walkErr = fmt.Errorf("finalize tar archive: %w", err)
+	}
+	if err := gz.Close(); walkErr == nil && err != nil {
+		walkErr = fmt.Errorf("finalize gzip stream: %w", err)
+	}
+	return walkErr
+}
+
+func publishBackupFile(dir, root string, meta archiveMetadata, retention int) (string, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(dir, ".backpack-backup-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	tempPath := f.Name()
+	randomSuffix := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(tempPath), ".backpack-backup-"), ".tmp")
+	name := fmt.Sprintf("backpack-backup-%s-%s.tar.gz", time.Now().Format("20060102-150405.000000000"), randomSuffix)
+	path := filepath.Join(dir, name)
+	keepTemp := true
+	defer func() {
+		if keepTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := f.Chmod(0600); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if err := writeBackupArchive(f, root, meta); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("sync backup archive: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close backup archive: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return "", fmt.Errorf("publish backup archive: %w", err)
+	}
+	keepTemp = false
+	pruneBackupFiles(dir, retention)
+	return path, nil
+}
+
+func pruneBackupFiles(dir string, retention int) {
+	matches, _ := filepath.Glob(filepath.Join(dir, "backpack-backup-*.tar.gz"))
+	if len(matches) <= retention {
+		return
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+	for _, old := range matches[retention:] {
+		_ = os.Remove(old)
+	}
+}

--- a/internal/manage/backup_write_test.go
+++ b/internal/manage/backup_write_test.go
@@ -1,0 +1,149 @@
+package manage
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWriteBackupProducesCompleteArchive(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "nested"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "nested", "tunnel.toml"), []byte("token = 'secret'\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var archive bytes.Buffer
+	meta := archiveMetadata{Version: "test", Created: "now", AutoRefreshHours: 6}
+	if err := writeBackupArchive(&archive, root, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(archive.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := tar.NewReader(gz)
+	entries := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries[hdr.Name] = string(data)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(entries[backupMetaName], `"auto_refresh_hours": 6`) {
+		t.Fatalf("metadata missing from archive: %q", entries[backupMetaName])
+	}
+	if entries["nested/tunnel.toml"] != "token = 'secret'\n" {
+		t.Fatalf("config file missing from archive: %#v", entries)
+	}
+}
+
+type failWriter struct {
+	remaining int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, errors.New("storage failed")
+	}
+	if len(p) > w.remaining {
+		n := w.remaining
+		w.remaining = 0
+		return n, errors.New("storage failed")
+	}
+	w.remaining -= len(p)
+	return len(p), nil
+}
+
+func TestWriteBackupPropagatesFinalWriterErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), bytes.Repeat([]byte("incompressible-ish-data-"), 100), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeBackupArchive(&failWriter{remaining: 8}, root, archiveMetadata{}); err == nil {
+		t.Fatal("backup succeeded after its destination stopped accepting data")
+	}
+}
+
+func TestWriteBackupRejectsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(t.TempDir(), "outside-secret")
+	if err := os.WriteFile(target, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "linked-secret")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	if err := writeBackupArchive(io.Discard, root, archiveMetadata{}); err == nil {
+		t.Fatal("backup followed or silently included a symlink")
+	}
+}
+
+func TestBackupToFilePublishesAtomically(t *testing.T) {
+	root := t.TempDir()
+	destination := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte("ok"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := publishBackupFile(destination, root, archiveMetadata{}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := publishBackupFile(destination, root, archiveMetadata{}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("two backups reused the same path %q", first)
+	}
+	for _, archive := range []string{first, second} {
+		info, err := os.Stat(archive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+			t.Fatalf("backup mode = %o, want 600", info.Mode().Perm())
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(destination, ".backpack-backup-*.tmp"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary backup files left behind: %v, err=%v", matches, err)
+	}
+}
+
+func TestBackupFailureLeavesNoPartialArchive(t *testing.T) {
+	destination := t.TempDir()
+	_, err := publishBackupFile(destination, filepath.Join(t.TempDir(), "missing"), archiveMetadata{}, 10)
+	if err == nil {
+		t.Fatal("backup of a missing source unexpectedly succeeded")
+	}
+	entries, readErr := os.ReadDir(destination)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed backup left files behind: %v", entries)
+	}
+}


### PR DESCRIPTION
## Summary
- close source files immediately during archive walking instead of deferring every close
- propagate tar/gzip finalization and destination write errors
- reject symlinks and unsupported config file types
- write to a mode-0600 temporary file, fsync it, and atomically rename the completed archive
- generate collision-resistant archive names and clean failed temporary files

## Verification
- archive integrity, writer failure, symlink, atomic publish, and cleanup tests repeated 20-50 times
- Linux manage cross-build and go vet

## Why this matters
The old writer could report success before gzip close failed, exhaust descriptors on large trees, and expose truncated backup files under their final name.