### PR TITLE
fix: restore backups transactionally

### DIFF
--- a/internal/manage/backup.go
+++ b/internal/manage/backup.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/backpack/backpack/internal/app"
@@ -150,8 +149,8 @@ func BackupToFile(dir string) (string, error) {
 	return path, nil
 }
 
-// Restore reads a backup archive produced by WriteBackup, extracts it into the
-// config directory (overwriting matching files, leaving others untouched), then
+// Restore validates a backup in a staging directory and atomically replaces
+// the configuration (preserving files not present in the archive), then
 // re-registers a systemd service for every tunnel it finds and starts them. It
 // also restores the auto-refresh schedule from the archive sidecar.
 //
@@ -160,91 +159,21 @@ func BackupToFile(dir string) (string, error) {
 func Restore(r io.Reader) (RestoreResult, error) {
 	var res RestoreResult
 
-	gz, err := gzip.NewReader(r)
+	archive, err := restoreArchive(
+		r,
+		app.ConfigDir,
+		filepath.Base(app.InstallPathFile),
+		filepath.Base(app.WebUIConfig),
+		filepath.Base(app.TelegramConfig),
+	)
 	if err != nil {
-		return res, fmt.Errorf("not a valid backup archive: %w", err)
-	}
-	defer gz.Close()
-	tr := tar.NewReader(gz)
-
-	if err := os.MkdirAll(app.ConfigDir, 0755); err != nil {
 		return res, err
 	}
-
-	sawConfig := false
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return res, fmt.Errorf("reading archive: %w", err)
-		}
-
-		// Sidecar: parse for out-of-tree settings, never write it to disk.
-		if hdr.Name == backupMetaName {
-			var m backupMeta
-			if data, err := io.ReadAll(tr); err == nil {
-				_ = json.Unmarshal(data, &m)
-				res.AutoRefreshHours = m.AutoRefreshHours
-			}
-			continue
-		}
-
-		// Guard against path traversal (zip-slip): the cleaned target must stay
-		// inside ConfigDir.
-		clean := filepath.Clean(hdr.Name)
-		if clean == "." || strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
-			return res, fmt.Errorf("refusing unsafe path in archive: %q", hdr.Name)
-		}
-
-		// install_path is machine-specific — it records where install.sh cloned
-		// the repo on THIS host. Keep the local value if present; only fall back
-		// to the archived one when none exists, so restoring on a new server
-		// doesn't point the updater at a directory that isn't there.
-		if clean == filepath.Base(app.InstallPathFile) && fileExists(app.InstallPathFile) {
-			continue
-		}
-		target := filepath.Join(app.ConfigDir, clean)
-		if rel, err := filepath.Rel(app.ConfigDir, target); err != nil || strings.HasPrefix(rel, "..") {
-			return res, fmt.Errorf("refusing unsafe path in archive: %q", hdr.Name)
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return res, err
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-				return res, err
-			}
-			mode := os.FileMode(hdr.Mode).Perm()
-			if mode == 0 {
-				mode = 0600
-			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
-			if err != nil {
-				return res, err
-			}
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return res, err
-			}
-			f.Close()
-			res.Files++
-
-			base := filepath.Base(target)
-			switch {
-			case base == filepath.Base(app.WebUIConfig):
-				res.WebUIConfig = true
-			case base == filepath.Base(app.TelegramConfig):
-				res.TelegramConfig = true
-			case strings.HasSuffix(base, ".toml"):
-				sawConfig = true
-			}
-		}
-	}
+	res.Files = archive.Files
+	res.WebUIConfig = archive.WebUIConfig
+	res.TelegramConfig = archive.TelegramConfig
+	res.AutoRefreshHours = archive.AutoRefreshHours
+	sawConfig := archive.SawConfig
 
 	if sawConfig {
 		// Re-register a systemd unit for every restored tunnel, then start them.
@@ -282,8 +211,10 @@ func Restore(r io.Reader) (RestoreResult, error) {
 	}
 
 	// Restore the auto-refresh schedule captured in the sidecar.
-	if res.AutoRefreshHours > 0 {
-		_ = schedule.SetAutoRefresh(res.AutoRefreshHours)
+	if archive.HasMetadata {
+		if err := schedule.SetAutoRefresh(res.AutoRefreshHours); err != nil {
+			return res, fmt.Errorf("configuration restored, but auto-refresh could not be updated: %w", err)
+		}
 	}
 
 	return res, nil

--- a/internal/manage/restore_archive.go
+++ b/internal/manage/restore_archive.go
@@ -1,0 +1,376 @@
+package manage
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	restoreMetadataName = ".backpack-backup.json"
+	maxRestoreEntries   = 10_000
+	maxRestoreFileSize  = 64 << 20
+	maxRestoreTotalSize = 512 << 20
+	maxRestoreMetaSize  = 64 << 10
+)
+
+type restoreMetadata struct {
+	Version          string `json:"version"`
+	Created          string `json:"created"`
+	AutoRefreshHours int    `json:"auto_refresh_hours"`
+}
+
+type restoreArchiveResult struct {
+	Files            int
+	WebUIConfig      bool
+	TelegramConfig   bool
+	AutoRefreshHours int
+	HasMetadata      bool
+	SawConfig        bool
+}
+
+func restoreArchive(r io.Reader, configDir, installPathName, webUIName, telegramName string) (restoreArchiveResult, error) {
+	var result restoreArchiveResult
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return result, fmt.Errorf("not a valid backup archive: %w", err)
+	}
+	gz.Multistream(false)
+
+	configDir, err = filepath.Abs(configDir)
+	if err != nil {
+		_ = gz.Close()
+		return result, err
+	}
+	parent := filepath.Dir(configDir)
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		_ = gz.Close()
+		return result, err
+	}
+	stage, err := os.MkdirTemp(parent, ".backpack-restore-stage-*")
+	if err != nil {
+		_ = gz.Close()
+		return result, err
+	}
+	keepStage := true
+	defer func() {
+		if keepStage {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+
+	if err := seedRestoreStage(configDir, stage); err != nil {
+		_ = gz.Close()
+		return result, fmt.Errorf("prepare restore transaction: %w", err)
+	}
+	preserveInstallPath := fileExistsAt(filepath.Join(configDir, installPathName))
+	tr := tar.NewReader(gz)
+	seen := make(map[string]struct{})
+	entries := 0
+	var totalSize int64
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			_ = gz.Close()
+			return result, fmt.Errorf("reading archive: %w", err)
+		}
+		entries++
+		if entries > maxRestoreEntries {
+			_ = gz.Close()
+			return result, fmt.Errorf("backup contains more than %d entries", maxRestoreEntries)
+		}
+		clean, err := safeRestorePath(hdr.Name)
+		if err != nil {
+			_ = gz.Close()
+			return result, err
+		}
+		key := filepath.ToSlash(clean)
+		if _, exists := seen[key]; exists {
+			_ = gz.Close()
+			return result, fmt.Errorf("duplicate path in backup: %q", hdr.Name)
+		}
+		seen[key] = struct{}{}
+
+		if hdr.Size < 0 {
+			_ = gz.Close()
+			return result, fmt.Errorf("negative size for backup entry %q", hdr.Name)
+		}
+		if key == restoreMetadataName {
+			if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+				_ = gz.Close()
+				return result, fmt.Errorf("backup metadata is not a regular file")
+			}
+			if hdr.Size > maxRestoreMetaSize {
+				_ = gz.Close()
+				return result, fmt.Errorf("backup metadata is too large")
+			}
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				_ = gz.Close()
+				return result, fmt.Errorf("read backup metadata: %w", err)
+			}
+			var meta restoreMetadata
+			if err := json.Unmarshal(data, &meta); err != nil {
+				_ = gz.Close()
+				return result, fmt.Errorf("invalid backup metadata: %w", err)
+			}
+			if meta.AutoRefreshHours < 0 || meta.AutoRefreshHours > 24*365 {
+				_ = gz.Close()
+				return result, fmt.Errorf("invalid auto-refresh interval in backup: %d", meta.AutoRefreshHours)
+			}
+			result.AutoRefreshHours = meta.AutoRefreshHours
+			result.HasMetadata = true
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if hdr.Size != 0 {
+				_ = gz.Close()
+				return result, fmt.Errorf("directory entry %q has file contents", hdr.Name)
+			}
+			target := filepath.Join(stage, clean)
+			if err := replaceWithDirectory(target, archiveMode(hdr.Mode, 0755)); err != nil {
+				_ = gz.Close()
+				return result, fmt.Errorf("restore directory %q: %w", hdr.Name, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if hdr.Size > maxRestoreFileSize || totalSize > maxRestoreTotalSize-hdr.Size {
+				_ = gz.Close()
+				return result, fmt.Errorf("backup contents exceed restore size limits")
+			}
+			totalSize += hdr.Size
+			if key == filepath.ToSlash(installPathName) && preserveInstallPath {
+				continue
+			}
+			target := filepath.Join(stage, clean)
+			if err := writeRestoredFile(target, tr, hdr.Size, archiveMode(hdr.Mode, 0600)); err != nil {
+				_ = gz.Close()
+				return result, fmt.Errorf("restore file %q: %w", hdr.Name, err)
+			}
+			result.Files++
+			base := filepath.Base(clean)
+			switch {
+			case base == webUIName:
+				result.WebUIConfig = true
+			case base == telegramName:
+				result.TelegramConfig = true
+			case strings.HasSuffix(base, ".toml"):
+				result.SawConfig = true
+			}
+		default:
+			_ = gz.Close()
+			return result, fmt.Errorf("unsupported entry type %d for %q", hdr.Typeflag, hdr.Name)
+		}
+	}
+
+	// tar reaches its own end marker before gzip reaches its checksum. Draining
+	// the gzip reader ensures a truncated or corrupted upload cannot commit.
+	if _, err := io.Copy(io.Discard, gz); err != nil {
+		_ = gz.Close()
+		return result, fmt.Errorf("verify backup checksum: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return result, fmt.Errorf("close backup archive: %w", err)
+	}
+	if err := commitRestoreStage(stage, configDir); err != nil {
+		return result, err
+	}
+	keepStage = false
+	return result, nil
+}
+
+func safeRestorePath(name string) (string, error) {
+	if name == "" || strings.Contains(name, "\\") {
+		return "", fmt.Errorf("refusing unsafe path in backup: %q", name)
+	}
+	clean := path.Clean(name)
+	if clean == "." || clean == ".." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("refusing unsafe path in backup: %q", name)
+	}
+	native := filepath.FromSlash(clean)
+	if filepath.IsAbs(native) || filepath.VolumeName(native) != "" {
+		return "", fmt.Errorf("refusing unsafe path in backup: %q", name)
+	}
+	return native, nil
+}
+
+func archiveMode(raw int64, fallback os.FileMode) os.FileMode {
+	mode := os.FileMode(raw).Perm()
+	if mode == 0 {
+		return fallback
+	}
+	return mode
+}
+
+func replaceWithDirectory(target string, mode os.FileMode) error {
+	if info, err := os.Lstat(target); err == nil && !info.IsDir() {
+		if err := os.Remove(target); err != nil {
+			return err
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(target, mode); err != nil {
+		return err
+	}
+	return os.Chmod(target, mode)
+}
+
+func writeRestoredFile(target string, src io.Reader, size int64, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(target); err == nil && !info.Mode().IsRegular() {
+		if info.IsDir() {
+			if err := os.RemoveAll(target); err != nil {
+				return err
+			}
+		} else if err := os.Remove(target); err != nil {
+			return err
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	written, copyErr := io.Copy(f, src)
+	if copyErr == nil && written != size {
+		copyErr = io.ErrUnexpectedEOF
+	}
+	if copyErr == nil {
+		copyErr = f.Sync()
+	}
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func seedRestoreStage(configDir, stage string) error {
+	info, err := os.Stat(configDir)
+	if os.IsNotExist(err) {
+		return os.Chmod(stage, 0755)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("configuration path is not a directory")
+	}
+	if err := os.Chmod(stage, info.Mode().Perm()); err != nil {
+		return err
+	}
+	return filepath.Walk(configDir, func(source string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(configDir, source)
+		if err != nil || rel == "." {
+			return err
+		}
+		target := filepath.Join(stage, rel)
+		switch {
+		case info.IsDir():
+			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+				return err
+			}
+			return os.Chmod(target, info.Mode().Perm())
+		case info.Mode().IsRegular():
+			return copyRestoreSeedFile(source, target, info.Mode().Perm())
+		default:
+			return fmt.Errorf("unsupported existing config file type: %s", source)
+		}
+	})
+}
+
+func copyRestoreSeedFile(source, target string, mode os.FileMode) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		_ = in.Close()
+		return err
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		_ = in.Close()
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	if copyErr == nil {
+		copyErr = out.Sync()
+	}
+	outCloseErr := out.Close()
+	inCloseErr := in.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if outCloseErr != nil {
+		return outCloseErr
+	}
+	return inCloseErr
+}
+
+func commitRestoreStage(stage, configDir string) error {
+	parent := filepath.Dir(configDir)
+	oldMarker, err := os.CreateTemp(parent, ".backpack-restore-previous-*")
+	if err != nil {
+		return fmt.Errorf("prepare restore rollback: %w", err)
+	}
+	old := oldMarker.Name()
+	if err := oldMarker.Close(); err != nil {
+		_ = os.Remove(old)
+		return fmt.Errorf("prepare restore rollback: %w", err)
+	}
+	if err := os.Remove(old); err != nil {
+		return fmt.Errorf("prepare restore rollback: %w", err)
+	}
+
+	hadPrevious := false
+	if _, err := os.Stat(configDir); err == nil {
+		if err := os.Rename(configDir, old); err != nil {
+			return fmt.Errorf("move current configuration aside: %w", err)
+		}
+		hadPrevious = true
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(stage, configDir); err != nil {
+		if hadPrevious {
+			if rollbackErr := os.Rename(old, configDir); rollbackErr != nil {
+				return fmt.Errorf("commit restore: %v (rollback also failed: %v)", err, rollbackErr)
+			}
+		}
+		return fmt.Errorf("commit restore: %w", err)
+	}
+	if hadPrevious {
+		if err := os.RemoveAll(old); err != nil {
+			return fmt.Errorf("restore committed but old configuration cleanup failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func fileExistsAt(name string) bool {
+	_, err := os.Stat(name)
+	return err == nil
+}

--- a/internal/manage/restore_archive_test.go
+++ b/internal/manage/restore_archive_test.go
@@ -1,0 +1,171 @@
+package manage
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type restoreTestEntry struct {
+	name string
+	body []byte
+	kind byte
+}
+
+func makeRestoreArchive(t *testing.T, entries ...restoreTestEntry) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	gz := gzip.NewWriter(&out)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		kind := entry.kind
+		if kind == 0 {
+			kind = tar.TypeReg
+		}
+		hdr := &tar.Header{Name: entry.name, Typeflag: kind, Mode: 0600, Size: int64(len(entry.body))}
+		if kind == tar.TypeDir {
+			hdr.Size = 0
+			hdr.Mode = 0755
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if len(entry.body) > 0 {
+			if _, err := tw.Write(entry.body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return out.Bytes()
+}
+
+func TestRestoreArchiveCommitsOnlyAfterValidation(t *testing.T) {
+	parent := t.TempDir()
+	configDir := filepath.Join(parent, "config")
+	if err := os.Mkdir(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "keep.txt"), []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "install_path"), []byte("local"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := json.Marshal(restoreMetadata{Version: "test", AutoRefreshHours: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := makeRestoreArchive(t,
+		restoreTestEntry{name: restoreMetadataName, body: meta},
+		restoreTestEntry{name: "install_path", body: []byte("remote")},
+		restoreTestEntry{name: "tunnel.toml", body: []byte("restored")},
+		restoreTestEntry{name: "webui.json", body: []byte("{}")},
+	)
+
+	result, err := restoreArchive(bytes.NewReader(archive), configDir, "install_path", "webui.json", "telegram.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.HasMetadata || result.AutoRefreshHours != 0 || !result.SawConfig || !result.WebUIConfig || result.Files != 2 {
+		t.Fatalf("unexpected restore result: %+v", result)
+	}
+	assertFileContent(t, filepath.Join(configDir, "keep.txt"), "keep")
+	assertFileContent(t, filepath.Join(configDir, "install_path"), "local")
+	assertFileContent(t, filepath.Join(configDir, "tunnel.toml"), "restored")
+	if matches, _ := filepath.Glob(filepath.Join(parent, ".backpack-restore-*")); len(matches) != 0 {
+		t.Fatalf("restore transaction left temporary paths: %v", matches)
+	}
+}
+
+func TestRestoreArchiveRejectsTraversalWithoutChangingConfig(t *testing.T) {
+	parent := t.TempDir()
+	configDir := filepath.Join(parent, "config")
+	if err := os.Mkdir(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "original"), []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	archive := makeRestoreArchive(t, restoreTestEntry{name: "../escaped", body: []byte("bad")})
+	if _, err := restoreArchive(bytes.NewReader(archive), configDir, "install_path", "webui.json", "telegram.json"); err == nil {
+		t.Fatal("path traversal archive was accepted")
+	}
+	assertFileContent(t, filepath.Join(configDir, "original"), "safe")
+	if _, err := os.Stat(filepath.Join(parent, "escaped")); !os.IsNotExist(err) {
+		t.Fatalf("traversal target exists, err=%v", err)
+	}
+}
+
+func TestRestoreArchiveRejectsBadChecksumWithoutChangingConfig(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), "config")
+	if err := os.Mkdir(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "original"), []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	archive := makeRestoreArchive(t, restoreTestEntry{name: "new.toml", body: []byte("new")})
+	archive[len(archive)-1] ^= 0xff
+	if _, err := restoreArchive(bytes.NewReader(archive), configDir, "install_path", "webui.json", "telegram.json"); err == nil {
+		t.Fatal("archive with an invalid gzip checksum was accepted")
+	}
+	assertFileContent(t, filepath.Join(configDir, "original"), "safe")
+	if _, err := os.Stat(filepath.Join(configDir, "new.toml")); !os.IsNotExist(err) {
+		t.Fatalf("corrupt restore modified active config, err=%v", err)
+	}
+}
+
+func TestRestoreArchiveRejectsLinksAndDuplicates(t *testing.T) {
+	for name, entries := range map[string][]restoreTestEntry{
+		"symlink": {
+			{name: "link", kind: tar.TypeSymlink},
+		},
+		"duplicate": {
+			{name: "same", body: []byte("one")},
+			{name: "same", body: []byte("two")},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			configDir := filepath.Join(t.TempDir(), "config")
+			archive := makeRestoreArchive(t, entries...)
+			if _, err := restoreArchive(bytes.NewReader(archive), configDir, "install_path", "webui.json", "telegram.json"); err == nil {
+				t.Fatalf("%s archive was accepted", name)
+			}
+			if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+				t.Fatalf("failed restore published a config directory, err=%v", err)
+			}
+		})
+	}
+}
+
+func TestSafeRestorePathRejectsCrossPlatformEscapes(t *testing.T) {
+	for _, unsafe := range []string{"", ".", "..", "../x", "/absolute", `..\x`, `C:\x`} {
+		if _, err := safeRestorePath(unsafe); err == nil {
+			t.Errorf("unsafe path %q was accepted", unsafe)
+		}
+	}
+	if got, err := safeRestorePath("nested/config.toml"); err != nil || filepath.ToSlash(got) != "nested/config.toml" {
+		t.Fatalf("safe path rejected: got=%q err=%v", got, err)
+	}
+}
+
+func assertFileContent(t *testing.T, name, want string) {
+	t.Helper()
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s = %q, want %q", name, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- extract and validate into a same-filesystem staging directory before changing active config
- enforce path, type, duplicate-entry, file-count, per-file, and total-size limits
- reject symlinks/hardlinks and verify the gzip checksum before commit
- preserve local install_path and files absent from older backups
- atomically swap the config tree with rollback on commit failure
- restore a disabled auto-refresh schedule correctly and surface schedule errors

## Verification
- valid, traversal, corrupt-checksum, link, duplicate, and cross-platform path tests repeated 20-50 times
- Linux manage cross-build and go vet

## Why this matters
A corrupt or malicious archive previously modified live files incrementally, leaving a partially restored production installation on failure.