### PR TITLE
fix: stop pprof servers across reloads

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -120,10 +120,7 @@ func runEngine(cfg *config.Config, ctx context.Context, configPath string, apply
 
 		srv := server.NewServer(&cfg.Server, ctx) // server
 		reportZeroCopy(ctx)
-		go srv.Start()
-
-		// Wait for shutdown signal
-		<-ctx.Done()
+		srv.Start()
 		srv.Stop()
 		logger.Println("shutting down server...")
 	case "client":
@@ -136,10 +133,7 @@ func runEngine(cfg *config.Config, ctx context.Context, configPath string, apply
 
 		clnt := client.NewClient(&cfg.Client, ctx) // client
 		reportZeroCopy(ctx)
-		go clnt.Start()
-
-		// Wait for shutdown signal
-		<-ctx.Done()
+		clnt.Start()
 		clnt.Stop()
 		logger.Println("shutting down client...")
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,11 +10,9 @@ import (
 	"github.com/backpack/backpack/config"
 
 	"github.com/backpack/backpack/internal/client/transport"
+	"github.com/backpack/backpack/internal/debugserver"
 	"github.com/backpack/backpack/internal/utils/handlers"
 	"github.com/backpack/backpack/internal/utils/network"
-
-	"net/http"
-	_ "net/http/pprof"
 
 	"github.com/sirupsen/logrus"
 )
@@ -48,12 +46,15 @@ func (c *Client) Start() {
 	// loopback: pprof is unauthenticated and its heap dump would expose the
 	// tunnel token. Reach it with `ssh -L 6061:127.0.0.1:6061 root@server`.
 	if c.config.PPROF {
+		pprofDone := make(chan struct{})
 		go func() {
+			defer close(pprofDone)
 			c.logger.Info("pprof listening on 127.0.0.1:6061 (loopback only)")
-			if err := http.ListenAndServe("127.0.0.1:6061", nil); err != nil {
+			if err := debugserver.Serve(c.ctx, "127.0.0.1:6061"); err != nil {
 				c.logger.Errorf("pprof server stopped: %v", err)
 			}
 		}()
+		defer func() { <-pprofDone }()
 	}
 
 	c.logger.Infof("client with remote address %s started successfully", c.config.RemoteAddr)

--- a/internal/debugserver/pprof.go
+++ b/internal/debugserver/pprof.go
@@ -1,0 +1,76 @@
+// Package debugserver hosts the opt-in pprof endpoint with an explicit
+// lifecycle and handler set. The server never serves the process-wide default
+// mux, so unrelated handlers cannot become reachable on the profiling port.
+package debugserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+)
+
+func Serve(ctx context.Context, addr string) error {
+	if ctx.Err() != nil {
+		return nil
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		_ = listener.Close()
+		return nil
+	}
+	return ServeListener(ctx, listener)
+}
+
+func ServeListener(ctx context.Context, listener net.Listener) error {
+	server := newServer(listener.Addr().String())
+	serveStopped := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				_ = server.Close()
+			}
+		case <-serveStopped:
+		}
+	}()
+
+	err := server.Serve(listener)
+	close(serveStopped)
+	<-shutdownDone
+	if errors.Is(err, http.ErrServerClosed) || ctx.Err() != nil {
+		return nil
+	}
+	return err
+}
+
+func newServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		mux.ServeHTTP(w, r)
+	})
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    16 << 10,
+	}
+}

--- a/internal/debugserver/pprof_test.go
+++ b/internal/debugserver/pprof_test.go
@@ -1,0 +1,72 @@
+package debugserver
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestPprofServerReleasesListenerOnCancellation(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- ServeListener(ctx, listener) }()
+
+	var response *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err = http.Get("http://" + addr + "/debug/pprof/")
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		cancel()
+		t.Fatalf("pprof did not start: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK || response.Header.Get("Cache-Control") != "no-store" || response.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("unexpected pprof response: status=%d headers=%v", response.StatusCode, response.Header)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pprof did not stop after cancellation")
+	}
+
+	rebound, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("pprof listener was not released: %v", err)
+	}
+	_ = rebound.Close()
+}
+
+func TestPprofServerLimits(t *testing.T) {
+	server := newServer("127.0.0.1:0")
+	if server.ReadHeaderTimeout != 10*time.Second || server.ReadTimeout != 15*time.Second ||
+		server.IdleTimeout != 60*time.Second || server.MaxHeaderBytes != 16<<10 {
+		t.Fatalf("unexpected pprof limits: %+v", server)
+	}
+}
+
+func TestCancelledContextDoesNotBind(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := Serve(ctx, "127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,11 +2,10 @@ package server
 
 import (
 	"context"
-	"net/http"
-	_ "net/http/pprof"
 	"time"
 
 	"github.com/backpack/backpack/config"
+	"github.com/backpack/backpack/internal/debugserver"
 	"github.com/backpack/backpack/internal/server/transport"
 	"github.com/backpack/backpack/internal/utils"
 	"github.com/backpack/backpack/internal/utils/handlers"
@@ -51,12 +50,15 @@ func (s *Server) Start() {
 	// is all an attacker needs to connect. Reach it over SSH instead:
 	//   ssh -L 6060:127.0.0.1:6060 root@server
 	if s.config.PPROF {
+		pprofDone := make(chan struct{})
 		go func() {
+			defer close(pprofDone)
 			s.logger.Info("pprof listening on 127.0.0.1:6060 (loopback only)")
-			if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+			if err := debugserver.Serve(s.ctx, "127.0.0.1:6060"); err != nil {
 				s.logger.Errorf("pprof server stopped: %v", err)
 			}
 		}()
+		defer func() { <-pprofDone }()
 	}
 
 	switch s.config.Transport {


### PR DESCRIPTION
## Summary
- replace fire-and-forget default-mux pprof listeners with an explicit server and handler set
- shut profiling down from the tunnel generation context with bounded graceful shutdown
- wait for Client/Server generation completion before reload starts the next one
- add HTTP header/read/idle limits and no-store responses

## Verification
- pprof start/cancel/rebind tests repeated 100 times
- Linux cmd/client/server cross-build and go vet

## Why this matters
Disabling pprof on reload did not stop the old listener, and a new enabled generation could race the still-bound port.