### PR TITLE
fix: bound configuration resource costs

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -16,7 +16,7 @@ import (
 
 const ( // Default values
 	defaultToken          = "backpack"
-	defaultChannelSize    = 2048
+	defaultChannelSize    = 1024
 	defaultRetryInterval  = 3 // only for client
 	defaultConnectionPool = 8
 	defaultLogLevel       = "info"
@@ -147,6 +147,9 @@ func applyDefaults(cfg *config.Config) {
 	// Mux concurrancy
 	if cfg.Server.MuxCon < 1 {
 		cfg.Server.MuxCon = defaultMuxCon
+	}
+	for _, warning := range enforceResourceLimits(cfg) {
+		logger.Warn(warning)
 	}
 
 	warnUnusedStreamBuffer(cfg)

--- a/cmd/resource_limits.go
+++ b/cmd/resource_limits.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/backpack/backpack/config"
+)
+
+const (
+	maxChannelSize        = 8 * 1024
+	maxConnectionPool     = 64
+	maxMuxSessions        = 64
+	maxMuxConcurrency     = 256
+	maxMuxFrameSize       = 65_535
+	maxMuxReceiveBuffer   = 32 << 20
+	maxSocketBuffer       = 8 << 20
+	muxClientMemoryBudget = 64 << 20
+)
+
+// enforceResourceLimits bounds values that directly size channels, socket
+// buffers, goroutine bursts, or SMUX receive windows. It returns warnings so
+// callers can choose how to surface operator-visible corrections.
+func enforceResourceLimits(cfg *config.Config) []string {
+	var warnings []string
+	capValue := func(name string, value *int, maximum int) {
+		if *value > maximum {
+			warnings = append(warnings, fmt.Sprintf("%s=%d exceeds the safe limit; using %d", name, *value, maximum))
+			*value = maximum
+		}
+	}
+
+	capValue("server.channel_size", &cfg.Server.ChannelSize, maxChannelSize)
+	capValue("client.connection_pool", &cfg.Client.ConnectionPool, maxConnectionPool)
+	capValue("server.mux_session", &cfg.Server.MuxSession, maxMuxSessions)
+	capValue("client.mux_session", &cfg.Client.MuxSession, maxMuxSessions)
+	capValue("server.mux_con", &cfg.Server.MuxCon, maxMuxConcurrency)
+	capValue("server.mux_framesize", &cfg.Server.MaxFrameSize, maxMuxFrameSize)
+	capValue("client.mux_framesize", &cfg.Client.MaxFrameSize, maxMuxFrameSize)
+	capValue("server.mux_recievebuffer", &cfg.Server.MaxReceiveBuffer, maxMuxReceiveBuffer)
+	capValue("client.mux_recievebuffer", &cfg.Client.MaxReceiveBuffer, maxMuxReceiveBuffer)
+	capValue("server.so_rcvbuf", &cfg.Server.SO_RCVBUF, maxSocketBuffer)
+	capValue("server.so_sndbuf", &cfg.Server.SO_SNDBUF, maxSocketBuffer)
+	capValue("client.so_rcvbuf", &cfg.Client.SO_RCVBUF, maxSocketBuffer)
+	capValue("client.so_sndbuf", &cfg.Client.SO_SNDBUF, maxSocketBuffer)
+
+	if cfg.Server.MaxStreamBuffer > cfg.Server.MaxReceiveBuffer {
+		warnings = append(warnings, "server.mux_streambuffer exceeds mux_recievebuffer; using the receive-buffer limit")
+		cfg.Server.MaxStreamBuffer = cfg.Server.MaxReceiveBuffer
+	}
+	if cfg.Client.MaxStreamBuffer > cfg.Client.MaxReceiveBuffer {
+		warnings = append(warnings, "client.mux_streambuffer exceeds mux_recievebuffer; using the receive-buffer limit")
+		cfg.Client.MaxStreamBuffer = cfg.Client.MaxReceiveBuffer
+	}
+
+	if clientUsesSMUX(cfg.Client.Transport) && cfg.Client.MaxReceiveBuffer > 0 {
+		maxPoolForBudget := muxClientMemoryBudget / cfg.Client.MaxReceiveBuffer
+		if maxPoolForBudget < 1 {
+			maxPoolForBudget = 1
+		}
+		if cfg.Client.ConnectionPool > maxPoolForBudget {
+			warnings = append(warnings, fmt.Sprintf(
+				"client connection_pool × mux_recievebuffer exceeds %d MiB; reducing connection_pool from %d to %d",
+				muxClientMemoryBudget>>20, cfg.Client.ConnectionPool, maxPoolForBudget))
+			cfg.Client.ConnectionPool = maxPoolForBudget
+		}
+	}
+	return warnings
+}
+
+func clientUsesSMUX(transport config.TransportType) bool {
+	switch transport {
+	case config.TCPMUX, config.KCP, config.XDI, config.WSMUX, config.WSSMUX, config.SPOOF:
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/resource_limits_test.go
+++ b/cmd/resource_limits_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/backpack/backpack/config"
+)
+
+func TestResourceLimitsBoundSMUXMemoryAndInvalidWindows(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			ChannelSize:      1 << 20,
+			MuxSession:       1000,
+			MuxCon:           1000,
+			MaxFrameSize:     1 << 20,
+			MaxReceiveBuffer: 1 << 30,
+			MaxStreamBuffer:  1 << 30,
+			SO_RCVBUF:        1 << 30,
+			SO_SNDBUF:        1 << 30,
+		},
+		Client: config.ClientConfig{
+			Transport:        config.WSMUX,
+			ConnectionPool:   1000,
+			MuxSession:       1000,
+			MaxFrameSize:     1 << 20,
+			MaxReceiveBuffer: 1 << 30,
+			MaxStreamBuffer:  1 << 30,
+			SO_RCVBUF:        1 << 30,
+			SO_SNDBUF:        1 << 30,
+		},
+	}
+	warnings := enforceResourceLimits(cfg)
+	if len(warnings) == 0 {
+		t.Fatal("dangerous configuration was silently accepted")
+	}
+	if cfg.Server.ChannelSize != maxChannelSize || cfg.Server.MuxSession != maxMuxSessions || cfg.Server.MuxCon != maxMuxConcurrency {
+		t.Fatalf("server allocation limits not applied: %+v", cfg.Server)
+	}
+	if cfg.Client.MaxReceiveBuffer != maxMuxReceiveBuffer || cfg.Client.MaxStreamBuffer != maxMuxReceiveBuffer {
+		t.Fatalf("client SMUX windows not bounded: receive=%d stream=%d", cfg.Client.MaxReceiveBuffer, cfg.Client.MaxStreamBuffer)
+	}
+	if cfg.Client.ConnectionPool*cfg.Client.MaxReceiveBuffer > muxClientMemoryBudget {
+		t.Fatalf("SMUX pool budget exceeded: pool=%d receive=%d", cfg.Client.ConnectionPool, cfg.Client.MaxReceiveBuffer)
+	}
+	if cfg.Server.SO_RCVBUF != maxSocketBuffer || cfg.Client.SO_SNDBUF != maxSocketBuffer {
+		t.Fatal("socket buffers were not bounded")
+	}
+}
+
+func TestResourceLimitsLeaveSafeValuesUntouched(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{ChannelSize: 1024, MuxSession: 2, MuxCon: 8, MaxFrameSize: 32768, MaxReceiveBuffer: 4 << 20, MaxStreamBuffer: 2 << 20},
+		Client: config.ClientConfig{Transport: config.WSMUX, ConnectionPool: 4, MuxSession: 2, MaxFrameSize: 32768, MaxReceiveBuffer: 4 << 20, MaxStreamBuffer: 2 << 20},
+	}
+	if warnings := enforceResourceLimits(cfg); len(warnings) != 0 {
+		t.Fatalf("safe configuration produced warnings: %v", warnings)
+	}
+	if cfg.Client.ConnectionPool != 4 || cfg.Client.MaxReceiveBuffer != 4<<20 || cfg.Server.ChannelSize != 1024 {
+		t.Fatalf("safe configuration changed: %+v", cfg)
+	}
+}
+
+func TestNonMuxPoolIsNotChargedAgainstSMUXBudget(t *testing.T) {
+	cfg := &config.Config{Client: config.ClientConfig{
+		Transport: config.TCP, ConnectionPool: 32, MaxReceiveBuffer: 32 << 20, MaxStreamBuffer: 1 << 20,
+	}}
+	enforceResourceLimits(cfg)
+	if cfg.Client.ConnectionPool != 32 {
+		t.Fatalf("plain TCP pool was capped as SMUX: %d", cfg.Client.ConnectionPool)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -59,29 +59,51 @@ type KCPConfig struct {
 	ParityShards int `toml:"kcp_parityshards"`
 }
 
+const (
+	maxKCPMTU    = 9_000
+	maxKCPWindow = 65_535
+	maxKCPShards = 32
+	maxKCPResend = 2
+)
+
 // WithDefaults returns a copy with any unset field filled in, so a config
 // written by an older version — or by hand — can never produce a KCP session
 // with a zero window or a zero tick interval.
 func (k KCPConfig) WithDefaults() KCPConfig {
 	if k.MTU <= 0 {
 		k.MTU = 1350
+	} else if k.MTU > maxKCPMTU {
+		k.MTU = maxKCPMTU
 	}
 	if k.Interval <= 0 {
 		k.Interval = 20
 	}
 	if k.Resend < 0 {
 		k.Resend = 2
+	} else if k.Resend > maxKCPResend {
+		k.Resend = maxKCPResend
 	}
 	if k.SndWnd <= 0 {
 		k.SndWnd = 1024
+	} else if k.SndWnd > maxKCPWindow {
+		k.SndWnd = maxKCPWindow
 	}
 	if k.RcvWnd <= 0 {
 		k.RcvWnd = 1024
+	} else if k.RcvWnd > maxKCPWindow {
+		k.RcvWnd = maxKCPWindow
 	}
 	// Parity without data shards is meaningless to the encoder, so treat a
 	// half-configured pair as FEC disabled rather than failing to start.
 	if k.DataShards <= 0 || k.ParityShards <= 0 {
 		k.DataShards, k.ParityShards = 0, 0
+	} else {
+		if k.DataShards > maxKCPShards {
+			k.DataShards = maxKCPShards
+		}
+		if k.ParityShards > maxKCPShards {
+			k.ParityShards = maxKCPShards
+		}
 	}
 	return k
 }

--- a/config/resource_limits_test.go
+++ b/config/resource_limits_test.go
@@ -1,0 +1,27 @@
+package config
+
+import "testing"
+
+func TestKCPDefaultsBoundAllocationInputs(t *testing.T) {
+	k := (KCPConfig{
+		MTU:          1 << 30,
+		Resend:       100,
+		SndWnd:       1 << 30,
+		RcvWnd:       1 << 30,
+		DataShards:   1 << 20,
+		ParityShards: 1 << 20,
+	}).WithDefaults()
+	if k.MTU != maxKCPMTU || k.Resend != maxKCPResend || k.SndWnd != maxKCPWindow || k.RcvWnd != maxKCPWindow {
+		t.Fatalf("KCP allocation inputs not bounded: %+v", k)
+	}
+	if k.DataShards != maxKCPShards || k.ParityShards != maxKCPShards {
+		t.Fatalf("KCP FEC shards not bounded: %d/%d", k.DataShards, k.ParityShards)
+	}
+}
+
+func TestKCPDefaultsPreserveValidTuning(t *testing.T) {
+	want := KCPConfig{MTU: 1350, Interval: 10, Resend: 2, NoDelay: 1, NoCongestion: 1, SndWnd: 8192, RcvWnd: 8192, DataShards: 10, ParityShards: 3}
+	if got := want.WithDefaults(); got != want {
+		t.Fatalf("valid KCP tuning changed: got %+v want %+v", got, want)
+	}
+}

--- a/internal/manage/preset.go
+++ b/internal/manage/preset.go
@@ -26,7 +26,7 @@ var presetOptions = []struct {
 }{
 	{"Balance", "light on CPU and RAM — best for small or shared VPS", PresetBalance},
 	{"Turbo", "recommended — the tuned default for Iran to abroad links", PresetTurbo},
-	{"Aggressive", "maximum throughput, noticeably more CPU — for strong servers", PresetAggressive},
+	{"Aggressive", "maximum throughput, noticeably more CPU and RAM — for strong servers", PresetAggressive},
 }
 
 // validPreset reports whether p is one of the three presets.
@@ -66,64 +66,62 @@ func ApplyPreset(s *TunnelSpec, preset string) {
 	case PresetBalance:
 		s.KeepAlive = 75
 		s.Heartbeat = 40
-		s.ChannelSize = 2048
-		s.ConnectionPool = 4
+		s.ChannelSize = 512
+		s.ConnectionPool = 2
 		// A steady pool keeps idle CPU low, which is the whole point of Balance.
 		s.AggressivePool = false
 		// Sizes the datagram socket only; TCP is auto-tuned by the kernel.
-		s.SoRcvBuf = 4 * 1024 * 1024
-		s.SoSndBuf = 4 * 1024 * 1024
+		s.SoRcvBuf = 1 * 1024 * 1024
+		s.SoSndBuf = 1 * 1024 * 1024
 		s.MuxCon = 4
 		s.MuxVersion = 2
 		s.MuxFrameSize = 32768
 		// 256 KB per stream ≈ 20 Mbit/s for one connection at 100 ms — modest
-		// on purpose, but four times what 64 KB allowed. Worst-case memory is
-		// MuxCon × MuxRecvBuffer = 4 × 4 MB.
-		s.MuxRecvBuffer = 4 * 1024 * 1024
+		// on purpose, but four times what 64 KB allowed. Two warm sessions each
+		// carry a 1 MB receive window, for a 2 MB aggregate ceiling.
+		s.MuxRecvBuffer = 1 * 1024 * 1024
 		s.MuxStreamBuffer = 256 * 1024
 
 	case PresetTurbo:
 		s.KeepAlive = 75
 		s.Heartbeat = 40
-		s.ChannelSize = 4096
-		s.ConnectionPool = 8 // enough warm connections without constant churn
+		s.ChannelSize = 2048
+		s.ConnectionPool = 4 // enough warm sessions without multiplying every window eightfold
 		// AggressivePool stays OFF here: it keeps the pool topped up in a tight
 		// loop and noticeably raises idle CPU. A normal pool is plenty.
 		s.AggressivePool = false
 		// Sizes the datagram socket only; TCP is auto-tuned by the kernel.
-		s.SoRcvBuf = 8 * 1024 * 1024
-		s.SoSndBuf = 8 * 1024 * 1024
+		s.SoRcvBuf = 2 * 1024 * 1024
+		s.SoSndBuf = 2 * 1024 * 1024
 		s.MuxCon = 8
 		s.MuxVersion = 2
 		s.MuxFrameSize = 32768
 		// 2 MB per stream ≈ 160 Mbit/s for a single connection at 100 ms RTT.
 		// This is the number that decides how fast one download feels, and the
-		// old 64 KB capped it at about 5 Mbit/s on that same path — the mux
-		// transports were being throttled by their own flow control long before
-		// the link ran out. Worst-case memory is MuxCon × MuxRecvBuffer = 8 × 16 MB.
-		s.MuxRecvBuffer = 16 * 1024 * 1024
+		// old 64 KB capped it at about 5 Mbit/s on that same path. Four warm
+		// sessions share 4 MB each, for a 16 MB aggregate ceiling.
+		s.MuxRecvBuffer = 4 * 1024 * 1024
 		s.MuxStreamBuffer = 2 * 1024 * 1024
 
 	case PresetAggressive:
 		s.KeepAlive = 60
 		s.Heartbeat = 25
-		s.ChannelSize = 8192
-		s.ConnectionPool = 16
+		s.ChannelSize = 4096
+		s.ConnectionPool = 8
 		// Refills the pool in a tight loop: lowest possible connect latency at
 		// the cost of real idle CPU. Only worth it on a server with cores spare.
 		s.AggressivePool = true
 		// Sizes the datagram socket only; TCP is auto-tuned by the kernel.
-		s.SoRcvBuf = 16 * 1024 * 1024
-		s.SoSndBuf = 16 * 1024 * 1024
+		s.SoRcvBuf = 4 * 1024 * 1024
+		s.SoSndBuf = 4 * 1024 * 1024
 		s.MuxCon = 16
 		s.MuxVersion = 2
 		s.MuxFrameSize = 65535
 		// 8 MB per stream ≈ 640 Mbit/s for a single connection at 100 ms RTT,
 		// which is what "maximum throughput" has to mean on this route. The
-		// memory is a ceiling on data actually in flight, not an allocation,
-		// but the worst case is real: MuxCon × MuxRecvBuffer = 16 × 32 MB, so
-		// this preset wants a server with RAM to spare — as it says it does.
-		s.MuxRecvBuffer = 32 * 1024 * 1024
+		// memory is a ceiling on data actually in flight, not an allocation.
+		// Eight warm sessions × 8 MB keep that aggregate ceiling at 64 MB.
+		s.MuxRecvBuffer = 8 * 1024 * 1024
 		s.MuxStreamBuffer = 8 * 1024 * 1024
 	}
 

--- a/internal/manage/preset_tuning_test.go
+++ b/internal/manage/preset_tuning_test.go
@@ -106,3 +106,18 @@ func TestPresetFECOverheadDoesNotGrowWithSpeed(t *testing.T) {
 			tur.KCPParityShards, agg.KCPParityShards)
 	}
 }
+
+func TestPresetResourceFootprintsAreBounded(t *testing.T) {
+	for _, preset := range []string{PresetBalance, PresetTurbo, PresetAggressive} {
+		s := presetOf(t, preset)
+		if footprint := s.ConnectionPool * s.MuxRecvBuffer; footprint > 64<<20 {
+			t.Errorf("%s SMUX receive-window footprint = %d MiB, want <= 64 MiB", preset, footprint>>20)
+		}
+		if s.ChannelSize > 4096 {
+			t.Errorf("%s channel_size = %d, want <= 4096", preset, s.ChannelSize)
+		}
+		if s.SoRcvBuf > 4<<20 || s.SoSndBuf > 4<<20 {
+			t.Errorf("%s socket buffers = %d/%d, want <= 4 MiB", preset, s.SoRcvBuf, s.SoSndBuf)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- cap channel, pool, mux, socket-buffer, KCP window/MTU, and FEC allocation inputs
- enforce a 64 MiB configured SMUX receive-window budget across client sessions
- preserve valid custom values and emit warnings whenever a dangerous value is corrected
- reduce new Balance/Turbo/Aggressive preset multiplication while retaining their per-stream throughput windows

## Verification
- pure config/resource-limit tests repeated 100 times
- Linux cmd/manage/e2e cross-build and go vet

## Relationship
Complements #17: this PR limits configured initial cost; #17 limits runtime SMUX pool growth.

## Why this matters
Previously valid TOML could multiply large receive windows and socket/KCP buffers across an unbounded pool, making OOM behavior a configuration typo away.