### PR TITLE
Fix possible fix(deps): golang.org/x/crypto v0.54.0 → 0.55.0 (CVE-2026-56854) in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/xtaci/kcp-go/v5 v5.6.72
 	github.com/xtaci/smux v1.5.27
-	golang.org/x/crypto v0.54.0
+	golang.org/x/crypto v0.55.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.14.0


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

CVE-2026-56854 is a critical vulnerability in golang.org/x/crypto that bypasses source-address restrictions in SSH authentication callbacks. Permissions configured via PasswordCallback, KeyboardInteractiveCallback, NoClientAuthCallback, and GSSAPIWithMICConfig.AllowLogin were not validated against the client's remote IP, allowing attackers from restricted networks to silently bypass access controls. This poses a severe risk of unauthorized access and network policy circumvention. Immediate remediation requires updating the dependency to v0.55.0.

Update golang.org/x/crypto from v0.54.0 to v0.55.0 to address CVE-2026-56854.

For reference: rule `CVE-2026-56854`. Rated critical.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
